### PR TITLE
tests:Disable cypress file watcher from CI test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "test:components": "cypress open-ct",
-    "test:components:run": "cypress run-ct",
+    "test:components:run": "cypress run-ct --config watchForFileChanges=false",
     "lint": "eslint \"./src/**/*.{ts,tsx}\"",
     "eject": "react-scripts eject",
     "format": "prettier --write src",


### PR DESCRIPTION
### Requirements for a pull request

Disable file watcher from test runs since its not needed in CI and it causes github actions to fail every now and then.
