### PR TITLE
fix:Artifact search stopping loader too early

### DIFF
--- a/src/hooks/useSearchField/index.ts
+++ b/src/hooks/useSearchField/index.ts
@@ -92,8 +92,6 @@ export default function useSeachField(flowID: string, runNumber: string): Search
         updateSearchResults({ result: event.matches || [], status: 'Ok' });
       } else if (event.type === 'error' && event.message) {
         updateSearchResults({ status: 'Error', errorMsg: event.message, result: [] });
-      } else {
-        updateSearchResults({ result: [], status: 'Ok' });
       }
     },
     onConnecting: () => {


### PR DESCRIPTION
### Description of the Change

Fixed artifact search loader disappearing too early. Search functionality wasnt used to progress messages.