### PR TITLE
fix:Add missing catch from service version request

### DIFF
--- a/src/utils/VERSION.ts
+++ b/src/utils/VERSION.ts
@@ -43,6 +43,9 @@ export function fetchServiceVersion(): void {
       if (value) {
         setServiceVersion(value);
       }
+    })
+    .catch(() => {
+      console.warn('Failed to fetch service version');
     });
 }
 


### PR DESCRIPTION
### Description of the Change

Server versions request was missing catch from it which could cause crash. This would not cause much of a difference anyways since if server is not responding UI won't work.