### PR TITLE
Added `embed` parameter to iframe src so that the `aside` is not shown

### DIFF
--- a/src/pages/Task/index.tsx
+++ b/src/pages/Task/index.tsx
@@ -378,7 +378,7 @@ const Task: React.FC<TaskViewProps> = ({
                       ),
                       component: (
                         <CardIframe
-                          path={`/flows/${task.flow_id}/runs/${task.run_number}/steps/${task.step_name}/tasks/${task.task_id}/cards/${def.hash}`}
+                          path={`/flows/${task.flow_id}/runs/${task.run_number}/steps/${task.step_name}/tasks/${task.task_id}/cards/${def.hash}?embed=true`}
                         />
                       ),
                     }))


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

The problem was that the `aside` (left nav) of the card was showing when the card was displayed in MFGUI.

There is a corresponding change to the metaflow card-generating code that checks for the `embed` parameter and adds a class to the HTML that already triggers CSS to hide the `aside`.

### Alternate Designs

Sending a post message to achieve this seemed overkill.

I looked into having the CSS detect whether it was embedded, without javascript but could not find a solution.

### Possible Drawbacks

Users may like the aside and see that what is displayed in MFGUI is different from the downloaded card (which will show the aside with a wider screen)

### Verification Process

* Run a flow with the changes in https://github.com/Netflix/metaflow/pull/877 e.g. `python3 dummyflow.py run --with card`
* Navigate to the task in MFGUI
* Ensure that the `aside` is not shown for the card.

### Release Notes

Adds a param to the card iframe to hide the aside in the card.
