### PR TITLE
Feat/show card

### DIFF
--- a/src/components/MFCard/useTaskCards.ts
+++ b/src/components/MFCard/useTaskCards.ts
@@ -2,9 +2,11 @@ import useResource, { Resource } from '../../hooks/useResource';
 import { Task } from '../../types';
 
 export type CardDefinition = {
+  // ID of custom card
+  id?: string;
   // Name of card
   type: string;
-  // Id of card, used for fetching card HTML
+  // Used for fetching card HTML
   hash: string;
 };
 

--- a/src/pages/Task/index.tsx
+++ b/src/pages/Task/index.tsx
@@ -351,7 +351,7 @@ const Task: React.FC<TaskViewProps> = ({
                   ? cards.data.map((def) => ({
                       key: def.hash,
                       order: 99,
-                      label: `${t('card.card_title')}: ${def.type}`,
+                      label: def.id ? `${t('card.card_id_title')}: ${def.id}` : `${t('card.card_title')}: ${def.type}`,
                       actionbar: (
                         <a
                           title={t('card.download_card')}

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -323,6 +323,7 @@ const en = {
     },
 
     card: {
+      card_id_title: 'Card ID',
       card_title: 'Card',
       download_card: 'Download Card HTML file',
     },


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Shows the ID of a custom card (if any) rather than the type when viewing the task page.

### Alternate Designs

* Showing the ID and the type - rejected because the type is usually "blank" and gives not new information

### Possible Drawbacks

\-

### Verification Process

* Run a flow that has a step with a card with an id e.g. ```    @card(type='blank',id='b')
    @step
    def x(self):```
* Go to MFGUI
* Find the task 
* Look at the right-side navigation for `Card ID: b` and the main body header above the card to say the same

### Release Notes

For this to work, there is a `metaflow-service` PR that needs to be merged to wire the ID through the API. This PR will not bork if that does not exist and will fallback to showing the card's type instead of the ID.
