### PR TITLE
fix: Replacing tags correctly when arriving from run page

### DIFF
--- a/src/pages/Home/Home.utils.ts
+++ b/src/pages/Home/Home.utils.ts
@@ -87,7 +87,11 @@ export function makeWebsocketParameters(
 // Check if current parameters are default params
 //
 export function isDefaultParams(params: Record<string, string>, checkTimerange: boolean, timezone?: string): boolean {
-  if (Object.keys(params).length === 4 || Object.keys(params).length === 5) {
+  const keys = Object.keys(params);
+  if (
+    (keys.length === 4 || keys.length === 5) &&
+    isAllowedValues(keys, ['_order', '_limit', '_group_limit', 'status', 'timerange_start'])
+  ) {
     if (
       params._order === defaultHomeParameters._order &&
       params._limit === defaultHomeParameters._limit &&
@@ -100,6 +104,10 @@ export function isDefaultParams(params: Record<string, string>, checkTimerange: 
     }
   }
   return false;
+}
+
+function isAllowedValues(source: string[], values: string[]): boolean {
+  return source.every((val) => values.includes(val));
 }
 
 //


### PR DESCRIPTION
### Description of the Change

Fixing issue #54. Desired tag was getting replaced by cached values