### PR TITLE
Add status to card loading

### DIFF
--- a/src/components/MFCard/__tests__/useTaskCards.test.cypress.tsx
+++ b/src/components/MFCard/__tests__/useTaskCards.test.cypress.tsx
@@ -7,11 +7,11 @@ import { Task } from '../../../types';
 import { Decorator } from '../../DAG/DAGUtils';
 
 const MockComponent: React.FC<{ task?: Task | null; decos?: Decorator[] }> = ({ task = null, decos = [] }) => {
-  const cards = useTaskCards(task, decos);
+  const cardsResult = useTaskCards(task, decos);
 
   return (
-    <div data-testid="cardslist">
-      {cards.map((value) => (
+    <div data-testid="cardslist" className={cardsResult.status}>
+      {cardsResult.cards.map((value) => (
         <div key={value.hash} data-testid="card">{JSON.stringify(value)}</div>
       ))}
     </div>
@@ -51,6 +51,7 @@ describe('useTaskCards', () => {
       { name: 'card', attributes: {}, statically_defined: false }
     ]} />);
     gid('cardslist').children().should('have.length', 1);
+    cy.get('.loading').should('have.length', 1);
 
     // Lets mock so that second request will return two results
     cy.intercept('**/cards*', createDataModel([
@@ -58,5 +59,6 @@ describe('useTaskCards', () => {
       { id: '321', type: 'xd', hash: 'unique2' }
     ], {}));
     gid('cardslist').children({ timeout: 6000 }).should('have.length', 2); 
+    cy.get('.success').should('have.length', 1);
   });
 });

--- a/src/components/TitledSection/index.tsx
+++ b/src/components/TitledSection/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 type HeaderProps = {
-  label?: string;
+  label?: React.ReactNode | string;
   actionbar?: React.ReactNode;
 };
 

--- a/src/pages/Task/components/AnchorMenu.tsx
+++ b/src/pages/Task/components/AnchorMenu.tsx
@@ -8,7 +8,7 @@ import { HEADER_SIZE_PX } from '../../../constants';
 
 type AnchorItem = {
   key: string;
-  label: string;
+  label: React.ReactNode | string;
   position?: number;
 };
 

--- a/src/pages/Task/components/AnchoredView.tsx
+++ b/src/pages/Task/components/AnchoredView.tsx
@@ -10,7 +10,7 @@ import TaskSection from './TaskSection';
 
 type AnchoredViewSection = {
   key: string;
-  label: string;
+  label: React.ReactNode | string;
   order: number;
   noTitle?: boolean;
   actionbar?: React.ReactNode;

--- a/src/pages/Task/components/TaskSection.tsx
+++ b/src/pages/Task/components/TaskSection.tsx
@@ -8,7 +8,7 @@ import { TitledSectionHeader } from '../../../components/TitledSection';
 
 type Props = {
   // Visible title for the section
-  label: string;
+  label: React.ReactNode | string;
   sectionkey: string;
   // Should title be hidden?
   noTitle?: boolean;

--- a/src/pages/Task/index.tsx
+++ b/src/pages/Task/index.tsx
@@ -388,6 +388,7 @@ const Task: React.FC<TaskViewProps> = ({
                               <Spinner sm />
                             </>
                           ),
+                          component: <></>,
                         },
                       ]
                     : []
@@ -400,6 +401,7 @@ const Task: React.FC<TaskViewProps> = ({
                           key: 'card_timeout',
                           order: 99,
                           label: t('card.card_timeout'),
+                          component: <></>,
                         },
                       ]
                     : []

--- a/src/pages/Task/index.tsx
+++ b/src/pages/Task/index.tsx
@@ -191,7 +191,7 @@ const Task: React.FC<TaskViewProps> = ({
   // Cards
   //
 
-  const cards = useTaskCards(
+  const cardsResult = useTaskCards(
     task,
     task && dagResult.data ? dagResult.data.steps[task.step_name]?.decorators || [] : [],
   );
@@ -351,7 +351,7 @@ const Task: React.FC<TaskViewProps> = ({
                   : []),
                 // Render cards at the end of sections if enabled by feature flags.
                 ...(FEATURE_FLAGS.CARDS
-                  ? cards.map((def) => ({
+                  ? cardsResult.cards.map((def) => ({
                       key: def.hash,
                       order: 99,
                       label: def.id ? `${t('card.card_id_title')}: ${def.id}` : `${t('card.card_title')}: ${def.type}`,
@@ -374,6 +374,35 @@ const Task: React.FC<TaskViewProps> = ({
                       ),
                       component: <CardIframe path={`${taskCardPath(task, def.hash)}?embed=true`} />,
                     }))
+                  : []),
+                // Show spinner if any cards are still loading
+                ...(FEATURE_FLAGS.CARDS
+                  ? cardsResult.status === 'loading'
+                    ? [
+                        {
+                          key: 'card_loading',
+                          order: 99,
+                          label: (
+                            <>
+                              <span>{t('card.card_loading')} </span>
+                              <Spinner sm />
+                            </>
+                          ),
+                        },
+                      ]
+                    : []
+                  : []),
+                // Show error if cards were not fetched before timeout
+                ...(FEATURE_FLAGS.CARDS
+                  ? cardsResult.status === 'timeout'
+                    ? [
+                        {
+                          key: 'card_timeout',
+                          order: 99,
+                          label: t('card.card_timeout'),
+                        },
+                      ]
+                    : []
                   : []),
               ].sort((a, b) => a.order - b.order)}
             />

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -325,7 +325,9 @@ const en = {
     card: {
       card_id_title: 'Card ID',
       card_title: 'Card',
-      download_card: 'Download Card HTML file',
+      download_card: 'Download card HTML file',
+      card_timeout: 'Timeout: loading cards',
+      card_loading: 'Loading cards',
     },
   },
 };


### PR DESCRIPTION
### Requirements for a pull request

- [x] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Adds a status to the return value from the `useTaskCards()` hook so that the status can show in the UI.

### Possible Drawbacks

More visual noise on the page.

### Verification Process

* Load MFGUI
* Start a flow with a number of tasks (preferably slow)
* Navigate to a recently started task in MFGUI
* Note the "loading" indicators
* Note the card appearing

<img width="1157" alt="Screen Shot 2022-01-21 at 3 19 36 PM" src="https://user-images.githubusercontent.com/93726128/150608101-47df446b-a65c-4f40-9a79-d710aaf3d3a9.png">


---

* Bork your `metaflow-service` (e.g. by switching to a branch that doesn't support cards)
* Load MFGUI
* Start a flow with a number of tasks (preferably slow)
* Navigate to a recently started task in MFGUI
* Note the "loading" indicators
* Note the card timeout message

<img width="1153" alt="Screen Shot 2022-01-21 at 3 22 34 PM" src="https://user-images.githubusercontent.com/93726128/150608078-5abe67c7-b096-4cb0-82e1-5b307b0f83b4.png">


### Release Notes

Shows status when loading cards
