### PR TITLE
Use maximum height of iframe

### DIFF
--- a/src/components/MFCard/CardIframe.tsx
+++ b/src/components/MFCard/CardIframe.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { apiHttp } from '../../constants';
 
+const CHECK_HEIGHT_INTERVAL = 1000;
+
 type Props = {
   path: string;
 };
@@ -18,12 +20,13 @@ const CardIframe: React.FC<Props> = ({ path }) => {
   useEffect(() => {
     setInterval(() => {
       if (ref.current) {
-        const h = ref.current.contentDocument?.documentElement.offsetHeight;
+        const body = ref.current.contentWindow?.document.body;
+        const h = Math.max(body?.scrollHeight ?? 0, body?.clientHeight ?? 0, body?.offsetHeight ?? 0);
         if (h) {
           setElementHeight(h);
         }
       }
-    }, 1000);
+    }, CHECK_HEIGHT_INTERVAL);
   }, []);
 
   return (


### PR DESCRIPTION
### Requirements for a pull request

Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

A bug was found where some cards were not showing.
The cause was found to be cards with a `<body>` with an absolute position that gave the `offsetHeight` as 0. So the code that set the iframe size for the card set to to 0.

The fix was to use the maximum of the `offsetHeight`, `clientHeight`, and `scrollHeight` instead. This is consistent with how plugin iframes set their size.

### Verification Process

* Generate a card with a body with an absolute position. 
* `NBFlow/6070/end/130917` is an example.
* Make sure the card is visible

### Release Notes

Fixed zero-height iframe for cards
