### PR TITLE
Added configurable number of days to display on list of runs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ declare global {
   interface Window {
     METAFLOW_SERVICE: string;
     FEATURES: FeatureFlags;
+    MF_NUM_DAYS: string;
   }
 }
 /**
@@ -31,3 +32,17 @@ export const apiWs = (path: string): string => formatUrl(METAFLOW_SERVICE_WS, pa
 
 export const HEADER_SIZE_PX = 112;
 export const HEADER_SIZE_REM = toRelativeSize(112 / 16);
+
+/**
+ * Look for number of days to display in following order:
+ *
+ * 1. `window.MF_NUM_DAYS` (during runtime, inject via index.html)
+ * 2. `process.env.REACT_APP_MF_NUM_DAYS` (during build)
+ * 3. Defaults to 30
+ */
+
+const DEFAULT_NUM_DAYS = 30;
+export const NUM_DAYS: number =
+  (window.MF_NUM_DAYS && parseInt(window.MF_NUM_DAYS, DEFAULT_NUM_DAYS)) ||
+  (process.env.REACT_APP_MF_NUM_DAYS && parseInt(process.env.REACT_APP_MF_NUM_DAYS, DEFAULT_NUM_DAYS)) ||
+  30;

--- a/src/pages/Home/Home.utils.ts
+++ b/src/pages/Home/Home.utils.ts
@@ -1,3 +1,4 @@
+import { NUM_DAYS } from '../../constants';
 import { QueryParam, Run } from '../../types';
 import { getTimeFromPastByDays } from '../../utils/date';
 import { omit } from '../../utils/object';
@@ -98,7 +99,7 @@ export function isDefaultParams(params: Record<string, string>, checkTimerange: 
       params.status?.indexOf('completed') > -1 &&
       params.status?.indexOf('running') > -1 &&
       params.status?.indexOf('failed') > -1 &&
-      (checkTimerange ? params.timerange_start === getTimeFromPastByDays(30, timezone).toString() : true)
+      (checkTimerange ? params.timerange_start === getTimeFromPastByDays(NUM_DAYS, timezone).toString() : true)
     ) {
       return true;
     }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -20,6 +20,7 @@ import {
 import ScrollToTop from './ScrollToTop';
 import { useHistory } from 'react-router';
 import { TimezoneContext } from '../../components/TimezoneProvider';
+import { NUM_DAYS } from '../../constants';
 
 type HomeCache = {
   active: boolean;
@@ -149,7 +150,7 @@ const Home: React.FC = () => {
       if (isDefaultParams(rawParams, false, timezone)) {
         // We want to add timerange filter if we are rolling with default params
         // but not in back event. In back event we should keep state we had
-        setQp({ timerange_start: getTimeFromPastByDays(30, timezone).toString() });
+        setQp({ timerange_start: getTimeFromPastByDays(NUM_DAYS, timezone).toString() });
       }
     }
   }, [historyAction, initialised]); // eslint-disable-line


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

Deliberately undocumented.

### Description of the Change

The UI currently shows runs for the last 30 days. This change makes that configurable so that a UI instance can show runs from further back than 30 days if there is sparse data.

### Alternate Designs

No alternatives considered

### Possible Drawbacks

It is possible to set an environment variable to an invalid number of days

### Verification Process

* `export REACT_APP_MF_NUM_DAYS=500`
* `yarn start`
Take a look at the `timerange_start` parameter on the UI. It should correspond with a timestamp that is 500 days ago [epoch converter tool](https://www.epochconverter.com/)


### Release Notes

Added option to configure the number of days to display on the index page.
