### PR TITLE
Fetch run metadata on the start step and not the _parameters one.

### DIFF
--- a/src/pages/Run/RunPage.tsx
+++ b/src/pages/Run/RunPage.tsx
@@ -80,7 +80,7 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
     initialData: [],
     subscribeToEvents: true,
     queryParams: {
-      step_name: '_parameters',
+      step_name: 'start',
     },
     onUpdate(items) {
       plContext.addDataToStore('run-metadata', metadataToRecord(items));


### PR DESCRIPTION
The _parameters step typically does not contain all the metadata
associated with the other steps. This fix simply fetches metadata
from the `start` step instead.

