### PR TITLE
Changed iframe key to be unique

### DIFF
--- a/src/components/Plugins/PluginRegisterSystem.tsx
+++ b/src/components/Plugins/PluginRegisterSystem.tsx
@@ -22,7 +22,7 @@ const PluginRegisterSystem: React.FC<{ baseurl?: string }> = ({ baseurl }) => {
         setDefinitions(plugins);
       })
       .catch((e) => console.log(e));
-  }, []); // eslint-disable-line
+  }, []);
 
   const messageListener = useCallback(
     (event: MessageEvent) => {
@@ -50,17 +50,19 @@ const PluginRegisterSystem: React.FC<{ baseurl?: string }> = ({ baseurl }) => {
 
   return (
     <HidingElement>
-      {toRegister.map((plg) => (
-        <iframe
-          key={plg.identifier}
-          height="0"
-          width="0"
-          name={plg.name}
-          title={plg.name}
-          src={pluginPath(plg, baseurl)}
-          sandbox="allow-scripts"
-        />
-      ))}
+      {toRegister.map((plg) => {
+        return (
+          <iframe
+            key={plg.name}
+            height="0"
+            width="0"
+            name={plg.name}
+            title={plg.name}
+            src={pluginPath(plg, baseurl)}
+            sandbox="allow-scripts"
+          />
+        );
+      })}
     </HidingElement>
   );
 };


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

The issue was that, when there were multiple plugins for a slot, sometimes one of them would not be registered.

#### How it works

* The plugins to appear are set by a `PLUGINS` env variable and read by `metaflow-service`.
* `metaflow-service` reads the `PLUGINS` variable and loads the plugins' code and checks their validity.
* The plugins' information is sent to `metaflow-ui` via a request to `/plugins`.
* `metaflow-ui` makes requests to `metaflow-service` to get the plugins' code.
* The plugins' codes are added in iframes to a hidden element on the page.
* The code in the iframes sends a postMessage to the window to register the plugin.
* Each registered plugin is rendered to the correct slot on the page, within an iframe and removed from the hidden element.

#### The problem

When a plugin was in the hidden element and sending a registration postMessage, sometimes the wrong id (name) was sent and the correct plugin was not registered.

This occurred because each iframe in the hidden element had the same [key](https://reactjs.org/docs/lists-and-keys.html) and React would get confused by this and sometimes mutate the wrong iframe.

#### The fix

Make the keys in the iframes in the hidden element unique.

### Alternate Designs

\-

### Possible Drawbacks

If plugin names are not unique, there will be problems. Names are used as ids in other code related to plugins, so if this happens, other things will boiek too.

### Verification Process

* `export PLUGINS='{"internal-plugins": {"paths": ["aws-batch", "run_debugger", "task_debugger","honeycomb"], "repository": "https://github.com/outerbounds/mfgui_plugins.git", "parameters": {"sandbox": "allow-same-origin allow-popups allow-popups-to-escape-sandbox"},"ref":"origin/main"}}'`
* Start `metaflow-service` (`docker-compose -f docker-compose.development.yml up`) and `metaflow-ui` (`yarn start`)
* Run a flow, if you don't have any in the system
* Go to a task. You should see **3** plugins. If you don't there will be a plugin in an iframe in a hidden element at the bottom of the DOM.

### Release Notes

Make keys unique for plugin iframes before registration.
