### PR TITLE
Removed abort() on rerender

### DIFF
--- a/src/components/FilterInput/index.tsx
+++ b/src/components/FilterInput/index.tsx
@@ -152,14 +152,21 @@ const FilterInput: React.FC<FilterInputProps> = ({
     setHasFocus(false);
   }, []);
 
+  const handleClick = useCallback(() => {
+    inputEl.current?.focus();
+  }, []);
+
+  const handleMouseDown = useCallback(() => {
+    if (inputEl?.current?.value) {
+      onSubmit(inputEl.current.value);
+      if (!noClear) {
+        setVal('');
+      }
+    }
+  }, [noClear, onSubmit]);
+
   return (
-    <InputWrapper
-      status={status}
-      active={hasFocus}
-      onClick={() => {
-        inputEl.current?.focus();
-      }}
-    >
+    <InputWrapper status={status} active={hasFocus} onClick={handleClick}>
       {sectionLabel && (
         <InputLabel active={hasFocus || val !== ''} status={status}>
           {sectionLabel}
@@ -182,14 +189,7 @@ const FilterInput: React.FC<FilterInputProps> = ({
           data-testid="filter-input-submit-button"
           status={status}
           focus={hasFocus}
-          onMouseDown={() => {
-            if (inputEl?.current?.value) {
-              onSubmit(inputEl.current.value);
-              if (!noClear) {
-                setVal('');
-              }
-            }
-          }}
+          onMouseDown={handleMouseDown}
         >
           {customIconElement
             ? customIconElement

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -27,6 +27,7 @@ const Tabs: React.FC<TabsProps> = ({ tabs, activeTab, widen }) => {
   // Using internal state & effect here to track active tab so component can be used as
   // standalone OR controlled component. I imagine we need to use it as controlled in most cases
   // since we want perma urls
+
   const [active, setActive] = useState(activeTab);
   useEffect(() => {
     setActive(activeTab);

--- a/src/pages/Home/ResultGroup/ResultGroupRow.tsx
+++ b/src/pages/Home/ResultGroup/ResultGroupRow.tsx
@@ -54,6 +54,22 @@ const ResultGroupRow: React.FC<Props> = ({ isStale, queryParams, updateListValue
     };
   }, [rowState]);
 
+  const handleMouseEnter = () => {
+    setIsHovering(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsHovering(false);
+  };
+
+  const handleToggleClick = () => {
+    if (rowState === RowState.Opening || rowState === RowState.Open) {
+      setRowState(RowState.Closing);
+    } else {
+      setRowState(RowState.Opening);
+    }
+  };
+
   return (
     <>
       <StyledTR
@@ -66,12 +82,8 @@ const ResultGroupRow: React.FC<Props> = ({ isStale, queryParams, updateListValue
         clickable
         stale={isStale}
         active={visible}
-        onMouseEnter={() => {
-          setIsHovering(true);
-        }}
-        onMouseLeave={() => {
-          setIsHovering(false);
-        }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         <ResultGroupCells
           r={run}
@@ -85,13 +97,7 @@ const ResultGroupRow: React.FC<Props> = ({ isStale, queryParams, updateListValue
           <VerticalToggle
             visible={visible || isHovering}
             active={rowState === RowState.Opening || rowState === RowState.Open}
-            onClick={() => {
-              if (rowState === RowState.Opening || rowState === RowState.Open) {
-                setRowState(RowState.Closing);
-              } else {
-                setRowState(RowState.Opening);
-              }
-            }}
+            onClick={handleToggleClick}
           />
         </td>
       </StyledTR>

--- a/src/pages/Task/components/AnchoredView.tsx
+++ b/src/pages/Task/components/AnchoredView.tsx
@@ -8,7 +8,7 @@ import TaskSection from './TaskSection';
 // Anchored View
 //
 
-type AnchoredViewSection = {
+export type AnchoredViewSection = {
   key: string;
   label: React.ReactNode | string;
   order: number;

--- a/src/utils/row.ts
+++ b/src/utils/row.ts
@@ -1,5 +1,5 @@
 import { Row } from '../components/Timeline/VirtualizedTimeline';
-import { TaskStatus } from '../types';
+import { Task, TaskStatus } from '../types';
 
 const takeSmallest = (a: Row): number | null =>
   a.type === 'task' ? a.data[0].started_at || Number.MAX_VALUE : a.data.ts_epoch;
@@ -75,3 +75,9 @@ export const getTaskLineStatus = (rows: Row[]): TaskStatus => {
   if (statuses.indexOf('unknown') > -1) return 'unknown';
   return 'completed';
 };
+
+/**
+ * Get current step name
+ */
+export const getCurrentStepName = (rows: Task[]): string =>
+  rows.find((row) => row.status === 'running')?.step_name || '';


### PR DESCRIPTION
### Requirements for a pull request

Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Fixed bug where there was an infinite loop when the first task was selected.

### Alternate Designs

Prevent re-renders of the `useLogData` hook.

### Possible Drawbacks

Removing `abort()` may mean requests that aren't needed will still continue.

### Verification Process

* Start a new flow
* In MFGUI, click on the run
* Click on the Task tab
* When `start` appears, click on the start step

MFGUI should not lock up

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
