### PR TITLE
Added feature flags when showing logs

### DIFF
--- a/src/pages/Task/index.tsx
+++ b/src/pages/Task/index.tsx
@@ -160,16 +160,19 @@ const Task: React.FC<TaskViewProps> = ({
 
   const logUrl = `/flows/${run.flow_id}/runs/${getRunId(run)}/steps/${stepName}/tasks/${task?.task_id}/logs/`;
 
+  // Show logs if feature flag is set
+  const showLogs = FEATURE_FLAGS.LOGS;
+
   // Standard out logs
-  const stdout = useLogData({
-    paused: !isCurrentTaskFinished,
+  const stdout: LogData = useLogData({
+    paused: !isCurrentTaskFinished || !showLogs,
     preload: task?.status === 'running',
     url: `${logUrl}out?attempt_id=${attemptId.toString()}`,
   });
 
   // Error logs
-  const stderr = useLogData({
-    paused: !isCurrentTaskFinished,
+  const stderr: LogData = useLogData({
+    paused: !isCurrentTaskFinished || !showLogs,
     preload: task?.status === 'running',
     url: `${logUrl}err?attempt_id=${attemptId.toString()}`,
   });
@@ -220,9 +223,6 @@ const Task: React.FC<TaskViewProps> = ({
 
   // Show cards if feature flag is set and the task has not failed
   const showCards = task?.status !== 'failed' && FEATURE_FLAGS.CARDS;
-
-  // Show logs if feature flag is set
-  const showLogs = FEATURE_FLAGS.LOGS;
 
   const setSection = useCallback((value: string | null) => setQp({ section: value }, 'replaceIn'), [setQp]);
   const selectHandler = useCallback((att) => setQp({ attempt: att }), [setQp]);

--- a/src/pages/Task/index.tsx
+++ b/src/pages/Task/index.tsx
@@ -221,6 +221,9 @@ const Task: React.FC<TaskViewProps> = ({
   // Show cards if feature flag is set and the task has not failed
   const showCards = task?.status !== 'failed' && FEATURE_FLAGS.CARDS;
 
+  // Show logs if feature flag is set
+  const showLogs = FEATURE_FLAGS.LOGS;
+
   const setSection = useCallback((value: string | null) => setQp({ section: value }, 'replaceIn'), [setQp]);
   const selectHandler = useCallback((att) => setQp({ attempt: att }), [setQp]);
   const setStdOutFullscreen = useCallback(() => setFullscreen({ type: 'logs', logtype: 'stdout' }), []);
@@ -325,55 +328,63 @@ const Task: React.FC<TaskViewProps> = ({
                 //
                 // Stdout logs
                 //
-                {
-                  key: 'stdout',
-                  order: 2,
-                  label: t('task.std-out'),
-                  component: (
-                    <>
-                      <SectionLoader
-                        minHeight={110}
-                        status={getLogSectionStatus(stdout)}
-                        error={stdout.error}
-                        component={
-                          <LogList
-                            onScroll={stdout.loadMore}
-                            logdata={stdout}
-                            downloadUrl={apiHttp(`${logUrl}/out/download?attempt_id=${task.attempt_id}`)}
-                            setFullscreen={setStdOutFullscreen}
-                          />
-                        }
-                      />
-                      {task.status === 'pending' && t('task.waiting-for-task-to-start')}
-                    </>
-                  ),
-                },
+                ...(showLogs
+                  ? [
+                      {
+                        key: 'stdout',
+                        order: 2,
+                        label: t('task.std-out'),
+                        component: (
+                          <>
+                            <SectionLoader
+                              minHeight={110}
+                              status={getLogSectionStatus(stdout)}
+                              error={stdout.error}
+                              component={
+                                <LogList
+                                  onScroll={stdout.loadMore}
+                                  logdata={stdout}
+                                  downloadUrl={apiHttp(`${logUrl}/out/download?attempt_id=${task.attempt_id}`)}
+                                  setFullscreen={setStdOutFullscreen}
+                                />
+                              }
+                            />
+                            {task.status === 'pending' && t('task.waiting-for-task-to-start')}
+                          </>
+                        ),
+                      },
+                    ]
+                  : []),
                 //
                 // Strerr logs
                 //
-                {
-                  key: 'stderr',
-                  order: 3,
-                  label: t('task.std-err'),
-                  component: (
-                    <>
-                      <SectionLoader
-                        minHeight={110}
-                        status={getLogSectionStatus(stderr)}
-                        error={stderr.error}
-                        component={
-                          <LogList
-                            onScroll={stderr.loadMore}
-                            logdata={stderr}
-                            downloadUrl={apiHttp(`${logUrl}/err/download?attempt_id=${task.attempt_id}`)}
-                            setFullscreen={setStdErrFullscreen}
-                          />
-                        }
-                      />
-                      {task.status === 'pending' && t('task.waiting-for-task-to-start')}
-                    </>
-                  ),
-                },
+                ...(showLogs
+                  ? [
+                      {
+                        key: 'stderr',
+                        order: 3,
+                        label: t('task.std-err'),
+                        component: (
+                          <>
+                            <SectionLoader
+                              minHeight={110}
+                              status={getLogSectionStatus(stderr)}
+                              error={stderr.error}
+                              component={
+                                <LogList
+                                  onScroll={stderr.loadMore}
+                                  logdata={stderr}
+                                  downloadUrl={apiHttp(`${logUrl}/err/download?attempt_id=${task.attempt_id}`)}
+                                  setFullscreen={setStdErrFullscreen}
+                                />
+                              }
+                            />
+                            {task.status === 'pending' && t('task.waiting-for-task-to-start')}
+                          </>
+                        ),
+                      },
+                    ]
+                  : []),
                 // Render artifacts if enabled by feature flags.
                 ...(FEATURE_FLAGS.ARTIFACT_TABLE
                   ? [

--- a/src/utils/FEATURE.ts
+++ b/src/utils/FEATURE.ts
@@ -9,6 +9,7 @@ const FEATURE_FLAGS = {
   ARTIFACT_SEARCH: (process.env.REACT_APP_FEATURE_ARTIFACT_SEARCH || '0') === '1',
   DEBUG_VIEW: (process.env.REACT_APP_FEATURE_DEBUG_VIEW || '1') === '1',
   CARDS: (process.env.REACT_APP_FEATURE_CARDS || '1') === '1',
+  LOGS: (process.env.REACT_APP_FEATURE_LOGS || '1') === '1',
   CACHE_DISABLE: false,
   DB_LISTEN_DISABLE: false,
   HEARTBEAT_DISABLE: false,


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

For [CUS-9](https://linear.app/outerbounds/issue/CUS-9/disable-log-viewer-and-card-viewer-in-metaflow-ui)

Adding a feature flag to control the display of the `stdout` and `stderr` logs in the task view.

The feature flag can be unset by adding `FEATURE_LOGS=0` to the dockerfile of `metaflow-service`.

The flag is on (`1`) by default, so MFGUI will show logs unless specifically requested not to.

### Alternate Designs

An alternative design would be to control the sending of logs from `metaflow-service`.

### Possible Drawbacks

The logs are still available by making a request to `metaflow-service`.

### Verification Process

* Add `FEATURE_LOGS=0` to the dockerfile. 
* Restart `metaflow-service`
* Navigate to a task page and see that the logs are not shown

### Release Notes

Added feature flag to disable showing of logs in MFGUI.
