### PR TITLE
Moved collapsable chevron to left

### DIFF
--- a/src/components/Collapsable/index.tsx
+++ b/src/components/Collapsable/index.tsx
@@ -45,7 +45,7 @@ const Collapsable: React.FC<CollapsableProps> = ({ children, title, animated = t
           }}
           data-testid="collapsable-header"
         >
-          <div>{title}</div>
+          <Title>{title}</Title>
           <Icon name="arrowDown" rotate={open ? 180 : 0} />
         </CollapsableHeader>
 
@@ -71,7 +71,7 @@ const CollapseContainer = styled.div`
 
 const CollapsableHeader = styled.div`
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   font-size: 0.875rem;
   font-weight: 500;
   line-height: 1.5rem;
@@ -91,6 +91,10 @@ const Content = styled.div<{ open: boolean; visible: boolean }>`
   position: ${(p) => (p.open ? 'static' : 'absolute')};
   width: 100%;
   visibility: ${(p) => (p.visible ? 'visible' : 'hidden')};
+`;
+
+const Title = styled.div`
+  margin-right: 1rem;
 `;
 
 export default Collapsable;


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

The Collapsable header has a chevron that indicates to the user that the section can be opened and closed. The chevron is aligned to the right of the screen and not very noticeable.

This change moves the chevron to the left, near the section title.

<img width="203" alt="Screen Shot 2023-03-06 at 2 43 18 PM" src="https://user-images.githubusercontent.com/93726128/223242307-1dc2dca1-2514-4c64-bf80-d46a8866c779.png">
<img width="323" alt="Screen Shot 2023-03-06 at 2 43 13 PM" src="https://user-images.githubusercontent.com/93726128/223242323-59975f3e-b437-48f4-85df-4d8821765910.png">
<img width="219" alt="Screen Shot 2023-03-06 at 2 41 45 PM" src="https://user-images.githubusercontent.com/93726128/223242331-84404c15-296a-40b8-8edd-320a4cd439d3.png">
<img width="256" alt="Screen Shot 2023-03-06 at 2 41 40 PM" src="https://user-images.githubusercontent.com/93726128/223242336-c3e93c08-1eed-47f1-a377-f35b88057d76.png">


### Alternate Designs

\-

### Possible Drawbacks

\-

### Verification Process

* Find a run on the homepage
* Click on the run
* Notice the `Details` section header has a chevron next to it

### Release Notes

Moved collapsable section chevron to the left to make it more discoverable.
