### PR TITLE
fix: check sender of message to ensure correct recipient

### DIFF
--- a/src/components/MFCard/CardIframe.tsx
+++ b/src/components/MFCard/CardIframe.tsx
@@ -25,13 +25,16 @@ const CardIframe: React.FC<Props> = ({ path }) => {
 
     // Listen for a message from the iframe to check the height.
     const listener = (e: MessageEvent) => {
-      if (e.data.type === MESSAGE_NAME.HEIGHT_CHECK) {
-        if (typeof e.data.height === 'number') {
-          // Stop checking iframe periodically if it tells us what height it is.
-          clearInterval(interval);
-          setElementHeight(e.data.height);
-        } else {
-          console.warn("Height assign request didn't have a height value");
+      // ensure the message is from the iframe we're interested in
+      if (e.source === ref.current?.contentWindow) {
+        if (e.data.type === MESSAGE_NAME.HEIGHT_CHECK) {
+          if (typeof e.data.height === 'number') {
+            // Stop checking iframe periodically if it tells us what height it is.
+            clearInterval(interval);
+            setElementHeight(e.data.height);
+          } else {
+            console.warn("Height assign request didn't have a height value");
+          }
         }
       }
     };


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

When a postMessage is received by the app, the source is checked against the recipient to ensure that it matches.

Fixes: https://github.com/Netflix/metaflow-ui/issues/99

### Alternate Designs

Checking that the recipient is correct by using an attribute of the iframe (like name)

### Possible Drawbacks

`e.source` may not be reliable - https://stackoverflow.com/questions/16266474/javascript-listen-for-postmessage-events-from-specific-iframe/47676007#47676007 - I did not experience this problem. If it is not reliable, the check will fail which is not a bad result as the height of the iframe will be periodically checked anyway.

### Verification Process

1. Add a plugin to metaflow-service. You can follow the steps for a simple plugin [here](https://github.com/outerbounds/mfgui_plugins/tree/main/task_debugger)
2. Run a flow with a card `python myflow.py run --with card`
3. Go to a task page in MFGUI that has both the plugin and the card
4. Check the heights of the iframes of the card and plugin

### Release Notes

Checks intended recipient of height-setting postMessage for cards
