### PR TITLE
Feat/execution triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaflow-ui",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "dependencies": {
     "@rehooks/component-size": "^1.0.3",

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -43,13 +43,10 @@ const CustomTooltip = styled.div`
       opacity: 1;
     }
 
-    &.place-bottom::before {
-      border-bottom: 7px solid #d0d0d0;
-      top: -7px;
-    }
-
-    &.place-bottom::after {
+    &.place-bottom::after,
+    &.place-top::after {
       border-bottom-color: #fff;
+      background: #fff;
     }
     &:hover {
       visibility: visible;

--- a/src/components/Trigger/__tests__/Trigger.test.cypress.tsx
+++ b/src/components/Trigger/__tests__/Trigger.test.cypress.tsx
@@ -13,12 +13,10 @@ describe('Trigger test', () => {
       <ThemeProvider theme={theme}>
         <Trigger
           triggerEventsValue={{
-            event_name: 'metaflow_flow_run_succeeded',
-            timestamp: 1663184739,
-            pathspec: `${flow_name}/${run_id}`,
-            flow_name,
-            run_id,
-            event_type: 'metaflow_service',
+            name: 'metaflow_flow_run_succeeded',
+            timestamp: '1663184739',
+            id: `${flow_name}/${run_id}`,
+            type: 'run',
           }}
         />
       </ThemeProvider>,

--- a/src/components/Trigger/index.tsx
+++ b/src/components/Trigger/index.tsx
@@ -6,12 +6,10 @@ import Tooltip from '../Tooltip';
 const MAX_LABEL_WIDTH = 20; // number of characters to show before truncating
 
 export type TriggerEventsValue = {
-  flow_name: string;
-  run_id?: string;
-  event_name: string;
-  event_type: 'metaflow_user' | 'metaflow_service';
-  timestamp: number;
-  pathspec: string;
+  id: string;
+  name: string;
+  type: 'run' | 'event';
+  timestamp: string;
 };
 
 //
@@ -30,12 +28,11 @@ type Props = {
  * @param className Enables styling of the component.
  */
 const Trigger: React.FC<Props> = ({ triggerEventsValue, className, showToolTip = true }) => {
-  const { pathspec } = triggerEventsValue;
+  const { id, type, name } = triggerEventsValue;
 
   // Only handles triggers from runs
-  const label = pathspec;
-  const link = '/' + pathspec;
-  const id = pathspec;
+  const label = type === 'run' ? id.split('/').slice(0, 2).join('/') : name;
+  const link = type === 'run' ? '/' + label : undefined;
   const linkToRun = Boolean(link);
   let displayLabel = label;
 
@@ -49,7 +46,7 @@ const Trigger: React.FC<Props> = ({ triggerEventsValue, className, showToolTip =
     <TriggerLine key={id} data-tip data-for={tooltipId} className={className}>
       <TriggerLink href={link}>
         <StyledIcon name="arrow" linkToRun={linkToRun} />
-        {showToolTip ? displayLabel : pathspec}
+        {showToolTip ? displayLabel : id}
       </TriggerLink>
       {showToolTip && <Tooltip id={tooltipId}>{label}</Tooltip>}
     </TriggerLine>

--- a/src/components/Triggers/index.tsx
+++ b/src/components/Triggers/index.tsx
@@ -23,7 +23,7 @@ const Triggers: React.FC<Props> = ({ triggerEventsValue, showMultiple = false })
   return showMultiple || triggerEventsValue.length < 2 ? (
     <TriggerWrapper>
       {triggerEventsValue?.map((triggerEventsValue: TriggerEventsValue) => (
-        <Trigger triggerEventsValue={triggerEventsValue} key={triggerEventsValue.pathspec} />
+        <Trigger triggerEventsValue={triggerEventsValue} key={triggerEventsValue.id ?? triggerEventsValue.name} />
       ))}
     </TriggerWrapper>
   ) : (
@@ -35,7 +35,11 @@ const Triggers: React.FC<Props> = ({ triggerEventsValue, showMultiple = false })
       <PopoverWrapper open={popoverOpen}>
         <Popover show>
           {triggerEventsValue?.map((triggerEventsValue: TriggerEventsValue) => (
-            <Trigger triggerEventsValue={triggerEventsValue} key={triggerEventsValue.pathspec} showToolTip={false} />
+            <Trigger
+              triggerEventsValue={triggerEventsValue}
+              key={triggerEventsValue.id ?? triggerEventsValue.name}
+              showToolTip={false}
+            />
           ))}
         </Popover>
       </PopoverWrapper>
@@ -68,7 +72,7 @@ const TriggersButton = styled.button`
 `;
 
 const TriggerWrapper = styled.div`
-  color: #fff;
+  color: inherit;
 `;
 
 export default Triggers;

--- a/src/pages/Home/ResultGroup/StartedAtCell.tsx
+++ b/src/pages/Home/ResultGroup/StartedAtCell.tsx
@@ -29,7 +29,7 @@ const StartedAtCell: React.FC<Props> = ({ run, link, timezone }) => {
 
   const onUpdate = useCallback((items: Metadata[]) => {
     const metadataRecord = metadataToRecord(items);
-    setMetadataRecord(metadataRecord);
+    setMetadataRecord((old) => ({ ...old, ...metadataRecord }));
   }, []);
 
   useResource<Metadata[], Metadata>({
@@ -41,13 +41,13 @@ const StartedAtCell: React.FC<Props> = ({ run, link, timezone }) => {
     fetchAllData: true,
   });
 
-  const hasTrigger = Boolean(metadataRecord?.['trigger_events']);
+  const hasTrigger = Boolean(metadataRecord?.['execution-triggers']);
 
   return (
     <TDWithLink link={hasTrigger ? undefined : link}>
       <WordBreak>{getRunStartTime(run, timezone)}</WordBreak>
       {hasTrigger ? (
-        <Triggers showMultiple triggerEventsValue={JSON.parse(metadataRecord?.['trigger_events'] ?? '')} />
+        <Triggers showMultiple triggerEventsValue={JSON.parse(metadataRecord?.['execution-triggers'] ?? '')} />
       ) : null}
     </TDWithLink>
   );

--- a/src/pages/Run/RunHeader.tsx
+++ b/src/pages/Run/RunHeader.tsx
@@ -21,6 +21,7 @@ import useResource from '../../hooks/useResource';
 import Triggers from '../../components/Triggers';
 import TitledRow from '../../components/TitledRow';
 import { getISOString } from '../../utils/date';
+import { TriggerEventsValue } from '../../components/Trigger';
 
 //
 // Typedef
@@ -52,10 +53,10 @@ const RunHeader: React.FC<Props> = ({ run, metadataRecord }) => {
     { label: t('fields.status'), value: <StatusField status={run.status} /> },
     {
       label: t('fields.triggered-by'),
-      value: metadataRecord?.['trigger_events'] ? (
-        <TriggersInHeader triggerEventsValue={JSON.parse(metadataRecord?.['trigger_events'])} />
+      value: metadataRecord?.['execution-triggers'] ? (
+        <TriggersInHeader triggerEventsValue={JSON.parse(metadataRecord?.['execution-triggers'])} />
       ) : null,
-      hidden: !Boolean(metadataRecord?.['trigger_events']),
+      hidden: !Boolean(metadataRecord?.['execution-triggers']),
     },
     {
       label: t('fields.user'),
@@ -93,8 +94,8 @@ const RunHeader: React.FC<Props> = ({ run, metadataRecord }) => {
     initialData: emptyArray,
   });
 
-  let triggerEventsData: Record<string, string>[] = metadataRecord?.['trigger_events']
-    ? JSON.parse(metadataRecord?.['trigger_events'])
+  let triggerEventsData: TriggerEventsValue[] = metadataRecord?.['execution-triggers']
+    ? JSON.parse(metadataRecord?.['execution-triggers'])
     : [];
 
   triggerEventsData = triggerEventsData.map((triggerEvent) => {
@@ -113,12 +114,12 @@ const RunHeader: React.FC<Props> = ({ run, metadataRecord }) => {
         <>
           <RunParameterTable params={params} />
 
-          {triggerEventsData.map((triggerEvent) => (
+          {triggerEventsData.map((triggerEvent: TriggerEventsValue) => (
             <TitledRow
               title={t('run.triggering-event')}
               type="table"
               content={triggerEvent}
-              key={triggerEvent.pathspec}
+              key={triggerEvent.id ?? triggerEvent.name}
             />
           ))}
 

--- a/src/pages/Run/RunPage.tsx
+++ b/src/pages/Run/RunPage.tsx
@@ -86,7 +86,8 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
   const onUpdate = useCallback(
     (items: Metadata[]) => {
       const record = metadataToRecord(items);
-      setMetadataRecord(record);
+
+      setMetadataRecord((old) => ({ ...old, ...record }));
       addDataToStore('run-metadata', record);
     },
     [addDataToStore],

--- a/src/pages/Task/components/TaskDetails.tsx
+++ b/src/pages/Task/components/TaskDetails.tsx
@@ -18,7 +18,6 @@ import styled from 'styled-components';
 import RenderMetadata from '../../../components/RenderMetadata';
 import DataHeader from '../../../components/DataHeader';
 import { Resource } from '../../../hooks/useResource';
-import Triggers from '../../../components/Triggers';
 
 type Props = {
   run: Run;
@@ -58,13 +57,7 @@ const TaskDetails: React.FC<Props> = ({ task, metadata, metadataResource, develo
       label: t('fields.status'),
       value: <StatusField status={task.status} />,
     },
-    {
-      label: t('fields.triggered-by'),
-      value: metadataParams?.['trigger_events'] ? (
-        <TriggersInHeader triggerEventsValue={JSON.parse(metadataParams?.['trigger_events'])} />
-      ) : null,
-      hidden: !Boolean(metadataParams?.['trigger_events']),
-    },
+
     {
       label: t('fields.started-at'),
       value: task.started_at ? getISOString(new Date(task.started_at), timezone) : '',
@@ -78,17 +71,6 @@ const TaskDetails: React.FC<Props> = ({ task, metadata, metadataResource, develo
       value: getAttemptDuration(task),
     },
   ];
-
-  let triggerEventsData: Record<string, string>[] = metadataParams?.['trigger_events']
-    ? JSON.parse(metadataParams?.['trigger_events'])
-    : [];
-
-  triggerEventsData = triggerEventsData.map((triggerEvent) => {
-    return {
-      ...triggerEvent,
-      timestamp: getISOString(new Date(triggerEvent.timestamp), timezone),
-    };
-  });
 
   return (
     <>
@@ -115,15 +97,6 @@ const TaskDetails: React.FC<Props> = ({ task, metadata, metadataResource, develo
                   content: metadataParams,
                 })}
           />
-
-          {triggerEventsData.map((triggerEvent) => (
-            <TitledRow
-              title={t('run.triggering-event')}
-              type="table"
-              content={triggerEvent}
-              key={triggerEvent.pathspec}
-            />
-          ))}
 
           {developerNote && <TitledRow type="default" title={'Developer note'} content={developerNote} />}
         </Collapsable>
@@ -161,12 +134,6 @@ export function getAttemptDuration(task: ITask): string {
 
 const HeaderContainer = styled.div`
   margin-bottom: 1rem;
-`;
-
-const TriggersInHeader = styled(Triggers)`
-  a {
-    color: #fff;
-  }
 `;
 
 export default TaskDetails;


### PR DESCRIPTION
### Requirements for a pull request


- [x] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Removed event trigger information from the task header and changed code to accept new data format.

### Alternate Designs

\-

### Possible Drawbacks

\-

### Verification Process

* Trigger a run from an event (with argo)
* Find that run in MFGUI
* See a trigger link in the run header but not in the task header

Link in `Started at` column of homepage
<img width="1124" alt="Screen Shot 2023-04-25 at 3 08 03 PM" src="https://user-images.githubusercontent.com/93726128/234404333-93e93636-171f-4c8d-b30f-0f3944e4cca2.png">

Information in `Details` dropdown of run page
<img width="785" alt="Screen Shot 2023-04-25 at 3 07 55 PM" src="https://user-images.githubusercontent.com/93726128/234404344-3e8ccef8-970b-4895-9348-32eb45199928.png">

No link in task header
<img width="1355" alt="Screen Shot 2023-04-25 at 3 07 47 PM" src="https://user-images.githubusercontent.com/93726128/234404353-1766818b-e9d4-43c3-8eb3-c7b9d1413089.png">

Link in run header
<img width="984" alt="Screen Shot 2023-04-25 at 3 07 39 PM" src="https://user-images.githubusercontent.com/93726128/234404357-3e1c51e2-1d73-4caf-be04-4615d03f0c03.png">


### Release Notes

Removed event trigger link from task header
