### PR TITLE
Feat/base path

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,6 +66,7 @@ Available environment variables:
 | Environment variable         | Description                                                   | Default |
 | ---------------------------- | ------------------------------------------------------------- | ------- |
 | `REACT_APP_METAFLOW_SERVICE` | UI service API endpoint (cannot be changed without a rebuild) | `/api`  |
+| `REACT_APP_BASE_PATH`        | Base path override for UI (e.g. `/some/new/path`)             | ``      |
 
 ## 3. Reverse proxy
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaflow-ui",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "dependencies": {
     "@rehooks/component-size": "^1.0.3",

--- a/plugin-api/dev/PluginDevEnvironment.tsx
+++ b/plugin-api/dev/PluginDevEnvironment.tsx
@@ -42,7 +42,7 @@ const PluginContent: React.FC<Props> = ({
         slot={slot}
         baseurl={baseurl}
         resourceParams={{
-          flow_id: 'Dev flow',
+          flow_id: 'Devflow',
           run_number: '1',
           step_name: 'start',
           task_id: '1',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ const App: React.FC = () => {
             <PluginsProvider>
               <LoggingProvider>
                 <GlobalStyle />
-                <Router>
+                <Router basename={process.env.REACT_APP_BASE_PATH}>
                   <QueryParamProvider ReactRouterRoute={Route}>
                     {flagsReceived ? (
                       <>


### PR DESCRIPTION
### Requirements for a pull request

Adding configurable base path for all URL's so that MFGUI can be used with a proxy.

### Description of the Change

`REACT_APP_BASE_PATH` can be set to prepend the path to all URL's

### Alternate Designs

\-

### Possible Drawbacks

This change does not affect API URL's nor websocket URL's. They should be able to be controlled through `REACT_APP_METAFLOW_SERVICE`

This change does not affect URL's specified in the `<head>` like "/favicon.ico"

### Verification Process

* `export REACT_APP_BASE_PATH="/mybasepath"`
* `yarn start`

See that all links have "/mybasepath" prepended to them

### Release Notes

Add REACT_APP_BASE_PATH
