### PR TITLE
Added start and end times to task tooltip

### DIFF
--- a/src/components/Timeline/TimelineRow/LineElement.tsx
+++ b/src/components/Timeline/TimelineRow/LineElement.tsx
@@ -82,7 +82,7 @@ const LineElement: React.FC<LineElementProps> = ({
     `${status === 'unknown' ? ` (${t('task.unable-to-find-status')})` : ''} ${getTimestampString(
       new Date(boxStartTime),
       timezone,
-    )}-${getTimestampString(new Date(boxStartTime + (duration ?? 0)), timezone)}`;
+    )}-${duration ? getTimestampString(new Date(boxStartTime + duration), timezone) : ''}`;
 
   return (
     <LineElementContainer

--- a/src/components/Timeline/TimelineRow/LineElement.tsx
+++ b/src/components/Timeline/TimelineRow/LineElement.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled, { DefaultTheme, keyframes, css } from 'styled-components';
 import { Step, Task } from '../../../types';
 import { StepRowData } from '../useTaskData';
@@ -9,6 +9,8 @@ import { useHistory } from 'react-router';
 import { getPathFor } from '../../../utils/routing';
 import { TasksSortBy } from '../useTaskListSettings';
 import { useTranslation } from 'react-i18next';
+import { getTimestampString } from '../../../utils/date';
+import { TimezoneContext } from '../../TimezoneProvider';
 
 //
 // Typedef
@@ -47,6 +49,8 @@ const LineElement: React.FC<LineElementProps> = ({
   paramsString,
 }) => {
   const { t } = useTranslation();
+  const { timezone } = useContext(TimezoneContext);
+
   const { push } = useHistory();
   const status = getRowStatus(row);
   // Extend visible area little bit to prevent lines seem like going out of bounds. Happens
@@ -73,6 +77,13 @@ const LineElement: React.FC<LineElementProps> = ({
 
   const labelPosition = getLengthLabelPosition(valueFromLeft, width);
 
+  const title =
+    formatDuration(duration) +
+    `${status === 'unknown' ? ` (${t('task.unable-to-find-status')})` : ''} ${getTimestampString(
+      new Date(boxStartTime),
+      timezone,
+    )}-${getTimestampString(new Date(boxStartTime + (duration ?? 0)), timezone)}`;
+
   return (
     <LineElementContainer
       style={{ transform: `translateX(${valueFromLeft}%)` }}
@@ -86,7 +97,7 @@ const LineElement: React.FC<LineElementProps> = ({
         }}
         data-testid="boxgraphic"
         dragging={dragging}
-        title={formatDuration(duration) + `${status === 'unknown' ? ` (${t('task.unable-to-find-status')})` : ''}`}
+        title={title}
         onClick={(e) => {
           if (row.type === 'task') {
             e.stopPropagation();


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Added the start and end times of a task to the tooltip that shows when the task is hovered in the timeline view.

This feature was requested by @romain-intel , who wanted an easier way to see the duration between tasks.

### Alternate Designs

* Hovering over the gap between tasks shows a duration of the time between them

### Possible Drawbacks

This change does not take resumed or restarted attempts into account. It only reflect the same start and end times as the timeline view.

### Verification Process

* Go to the timeline view for a run
* Hover your mouse over a task line
* Confirm that the start and end times are the same as those shown when you click on the task

### Release Notes

Added start and end times to timeline tooltip
