### PR TITLE
fix: realtime timeline updates for runs with run_id

### DIFF
--- a/src/pages/Home/ResultGroup/ParametersPreview.tsx
+++ b/src/pages/Home/ResultGroup/ParametersPreview.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import Collapsable from '../../../components/Collapsable';
 import useResource from '../../../hooks/useResource';
 import { Run, RunParam } from '../../../types';
-import { getRunId } from '../../../utils/run';
 import RunParameterTable from '../../Run/RunParameterTable';
 
 const emptyObj = {};
@@ -11,7 +10,7 @@ const emptyObj = {};
 const ParametersPreview: React.FC<{ run: Run }> = ({ run }) => {
   const { t } = useTranslation();
   const params = useResource<RunParam, RunParam>({
-    url: `/flows/${run.flow_id}/runs/${getRunId(run)}/parameters`,
+    url: `/flows/${run.flow_id}/runs/${run.run_number}/parameters`,
     subscribeToEvents: true,
     initialData: emptyObj,
   });

--- a/src/pages/Home/ResultGroup/StartedAtCell.tsx
+++ b/src/pages/Home/ResultGroup/StartedAtCell.tsx
@@ -4,7 +4,7 @@ import Triggers from '../../../components/Triggers';
 import useResource from '../../../hooks/useResource';
 import { Metadata, Run } from '../../../types';
 import { metadataToRecord } from '../../../utils/metadata';
-import { getRunId, getRunStartTime } from '../../../utils/run';
+import { getRunStartTime } from '../../../utils/run';
 import { TDWithLink } from './ResultGroupCells';
 
 const emptyArray: Metadata[] = [];
@@ -33,7 +33,7 @@ const StartedAtCell: React.FC<Props> = ({ run, link, timezone }) => {
   }, []);
 
   useResource<Metadata[], Metadata>({
-    url: `/flows/${run.flow_id}/runs/${getRunId(run)}/metadata`,
+    url: `/flows/${run.flow_id}/runs/${run.run_number}/metadata`,
     initialData: emptyArray,
     subscribeToEvents: true,
     queryParams: initialQueryParams,

--- a/src/pages/Home/ResultGroup/TimelinePreview.tsx
+++ b/src/pages/Home/ResultGroup/TimelinePreview.tsx
@@ -8,7 +8,6 @@ import { startAndEndpointsOfRows } from '../../../utils/row';
 import styled from 'styled-components';
 import { Row } from '../../../components/Timeline/VirtualizedTimeline';
 import { Run } from '../../../types';
-import { getRunId } from '../../../utils/run';
 
 const zeroCounts = { all: 0, failed: 0, running: 0, completed: 0, unknown: 0, pending: 0 };
 
@@ -25,7 +24,7 @@ type TimelinePreviewProps = {
 //
 
 const TimelinePreview: React.FC<TimelinePreviewProps> = ({ run }) => {
-  const { rows, steps, dispatch, taskStatus } = useTaskData(run.flow_id, getRunId(run));
+  const { rows, steps, dispatch, taskStatus } = useTaskData(run.flow_id, run.run_number.toString());
   const [preview, setPreview] = useState<{ start: number; end: number; visiblerows: Row[] } | null>(null);
 
   useEffect(() => {

--- a/src/pages/Run/RunHeader.tsx
+++ b/src/pages/Run/RunHeader.tsx
@@ -82,13 +82,13 @@ const RunHeader: React.FC<Props> = ({ run, metadataRecord }) => {
   ];
 
   const params = useResource<RunParam, RunParam>({
-    url: `/flows/${run.flow_id}/runs/${getRunId(run)}/parameters`,
+    url: `/flows/${run.flow_id}/runs/${run.run_number}/parameters`,
     subscribeToEvents: true,
     initialData: emptyObj,
   });
 
   const dstype = useResource<Artifact[], Artifact>({
-    url: `/flows/${run.flow_id}/runs/${getRunId(run)}/artifacts`,
+    url: `/flows/${run.flow_id}/runs/${run.run_number}/artifacts`,
     queryParams: initialQueryParams,
     subscribeToEvents: true,
     initialData: emptyArray,

--- a/src/pages/Run/RunPage.tsx
+++ b/src/pages/Run/RunPage.tsx
@@ -76,7 +76,7 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
 
   const { rows, steps, dispatch, counts, taskStatus, isAnyGroupOpen, taskError, stepError } = useRowData(
     params.flowId,
-    getRunId(run),
+    run.run_number.toString(),
   );
 
   //
@@ -98,7 +98,7 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
   }, [clearDataStore]);
 
   useResource<Metadata[], Metadata>({
-    url: `/flows/${run.flow_id}/runs/${getRunId(run)}/metadata`,
+    url: `/flows/${run.flow_id}/runs/${run.run_number}/metadata`,
     initialData: emptyArray,
     subscribeToEvents: true,
     queryParams: initialQueryParams,
@@ -220,7 +220,7 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
   // DAG data, fetch here to prevent multiple fetches when switching tabs
   //
   const dagResult = useResource<GraphModel, GraphModel>({
-    url: encodeURI(`/flows/${run.flow_id}/runs/${getRunId(run)}/dag`),
+    url: encodeURI(`/flows/${run.flow_id}/runs/${run.run_number}/dag`),
     subscribeToEvents: false,
     initialData: null,
   });

--- a/src/pages/Task/index.tsx
+++ b/src/pages/Task/index.tsx
@@ -34,7 +34,7 @@ import { Decorator, GraphModel } from '../../components/DAG/DAGUtils';
 import useLogData, { LogData } from '../../hooks/useLogData';
 import { apiHttp } from '../../constants';
 import useTaskMetadata from './useTaskMetadata';
-import { getRunId, getTagOfType } from '../../utils/run';
+import { getTagOfType } from '../../utils/run';
 import useTaskCards, { taskCardPath } from '../../components/MFCard/useTaskCards';
 import CardIframe from '../../components/MFCard/CardIframe';
 import Button from '../../components/Button';
@@ -125,7 +125,7 @@ const Task: React.FC<TaskViewProps> = ({
     status,
     error,
   } = useResource<ITask[], ITask>({
-    url: `/flows/${run.flow_id}/runs/${getRunId(run)}/steps/${stepName}/tasks/${taskId}/attempts?postprocess=true`,
+    url: `/flows/${run.flow_id}/runs/${run.run_number}/steps/${stepName}/tasks/${taskId}/attempts?postprocess=true`,
     subscribeToEvents: true,
     initialData: null,
     updatePredicate,
@@ -153,12 +153,12 @@ const Task: React.FC<TaskViewProps> = ({
 
   // Metadata
   const metadata = useTaskMetadata({
-    url: `/flows/${run.flow_id}/runs/${getRunId(run)}/steps/${stepName}/tasks/${task?.task_id}/metadata`,
+    url: `/flows/${run.flow_id}/runs/${run.run_number}/steps/${stepName}/tasks/${task?.task_id}/metadata`,
     attemptId: attemptId,
     paused: !task,
   });
 
-  const logUrl = `/flows/${run.flow_id}/runs/${getRunId(run)}/steps/${stepName}/tasks/${task?.task_id}/logs/`;
+  const logUrl = `/flows/${run.flow_id}/runs/${run.run_number}/steps/${stepName}/tasks/${task?.task_id}/logs/`;
 
   // Standard out logs
   const stdout = useLogData({
@@ -189,7 +189,7 @@ const Task: React.FC<TaskViewProps> = ({
 
   // Artifacts
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
-  const artifactUrl = `/flows/${run.flow_id}/runs/${getRunId(run)}/steps/${stepName}/tasks/${task?.task_id}/artifacts`;
+  const artifactUrl = `/flows/${run.flow_id}/runs/${run.run_number}/steps/${stepName}/tasks/${task?.task_id}/artifacts`;
   const { status: artifactStatus, error: artifactError } = useResource<Artifact[], Artifact>({
     url: artifactUrl,
     queryParams,


### PR DESCRIPTION
### Requirements for a pull request

Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Reverts parts of #76 as subscriptions to resource updates over the web socket require passing in `run_number` instead of `run_id`. The user visible parts should remain using `run_id` when available.

Addresses #102

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
<!-- Mark '\-' if not applicable to the change -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- Mark '\-' if not applicable to the change -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

Mark '\-' if not applicable to the change

-->

### Release Notes

Fixes issue with realtime updates in timeline for runs with `run_id`

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
