### PR TITLE
Bug/no cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaflow-ui",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "dependencies": {
     "@rehooks/component-size": "^1.0.3",

--- a/src/components/MFCard/useTaskCards.ts
+++ b/src/components/MFCard/useTaskCards.ts
@@ -84,6 +84,15 @@ export default function useTaskCards(task: Task | null, decorators: Decorator[])
                 status: result.data.length >= expectedCards.length ? 'success' : prev[path]?.status,
               },
             }));
+          } else {
+            // The request returned a 500 because there are no cards for this task
+            setTaskCards((prev) => ({
+              ...prev,
+              [path]: {
+                cards: prev[path]?.cards ?? [],
+                status: result.status === 500 ? 'success' : 'error',
+              },
+            }));
           }
         })
         .catch((e) => {


### PR DESCRIPTION
### Requirements for a pull request

Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

When there are no cards for a run, the `/cards` request returns a 500. When this happens the UI needs to NOT show an error.

### Alternate Designs

Change the backend to return `[]` rather than an exception

### Possible Drawbacks

Real errors may be hidden

### Verification Process

Navigate to a task without a card.
See `Loading cards`, then nothing. No errors or timeout messages.

### Release Notes

Handle UI for tasks without cards
