### PR TITLE
Bug/plugin sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaflow-ui",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "dependencies": {
     "@rehooks/component-size": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaflow-ui",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "dependencies": {
     "@rehooks/component-size": "^1.0.3",

--- a/src/components/Plugins/PluginRegisterSystem.tsx
+++ b/src/components/Plugins/PluginRegisterSystem.tsx
@@ -59,7 +59,7 @@ const PluginRegisterSystem: React.FC<{ baseurl?: string }> = ({ baseurl }) => {
             name={plg.name}
             title={plg.name}
             src={pluginPath(plg, baseurl)}
-            sandbox="allow-scripts"
+            sandbox={`allow-scripts ${plg.parameters?.sandbox || ''}`}
           />
         );
       })}


### PR DESCRIPTION
### Requirements for a pull request

Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

MFGUI loads plugins into a separate iframe for registration before putting the iframe in the correct slot.
I had a situation where the registered plugin was failing because it did not have the same sandbox parameters as the real plugin slot.

This change replicates the iframe sandbox parameters so that the registration iframe and the plugin slot iframe are consistent.

### Alternate Designs

Fix the plugin so that it doesn't throw an error when it fails. This would solve the immediate problem but a better solution is the one proposed as it will reduce confusion for future plugins.

### Possible Drawbacks

\-

### Verification Process

* Install a plugin that makes a HTTP request that requires the origin to be set and a cookie to be passed from the MFGUI domain
* This plugin should not error while being registered

### Release Notes

Make sandbox parameters for plugins consistent in registration slot
