### PR TITLE
allow to modify base path at runtime

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,8 @@ import Announcements from './components/Announcement';
 import { PluginsProvider } from './components/Plugins/PluginManager';
 import PluginRegisterSystem from './components/Plugins/PluginRegisterSystem';
 
+import { appBasePath } from './constants';
+
 const App: React.FC = () => {
   const { t } = useTranslation();
   // Features list must be fetched before we render application so we don't render things that
@@ -46,7 +48,7 @@ const App: React.FC = () => {
             <PluginsProvider>
               <LoggingProvider>
                 <GlobalStyle />
-                <Router basename={process.env.REACT_APP_BASE_PATH}>
+                <Router basename={appBasePath}>
                   <QueryParamProvider ReactRouterRoute={Route}>
                     {flagsReceived ? (
                       <>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ import { toRelativeSize } from './utils/style';
 declare global {
   interface Window {
     METAFLOW_SERVICE: string;
+    APP_BASE_PATH: string | undefined;
     FEATURES: FeatureFlags;
     MF_DEFAULT_TIME_FILTER_DAYS: string;
   }
@@ -19,6 +20,9 @@ const metaflowServiceUrl = new URL(
   window.METAFLOW_SERVICE || process.env.REACT_APP_METAFLOW_SERVICE || '/api',
   document.baseURI,
 );
+
+export const appBasePath = window.APP_BASE_PATH ?? process.env.REACT_APP_BASE_PATH;
+
 const protocolWs = metaflowServiceUrl.protocol === 'https:' ? 'wss:' : 'ws:';
 
 export const METAFLOW_SERVICE = metaflowServiceUrl.href.replace(/\/$/, '');


### PR DESCRIPTION

### Description of the Change

Extend existing functionality with REACT_APP_BASE_PATH: previously that variable would have need to be set at compile time. This PR adds an alternative way to set it via `window.`, similar to how we treat `METAFLOW_SERVICE` setting

