### PR TITLE
Step status color not always correct #129

### DIFF
--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -11,7 +11,8 @@ type CheckboxFieldProps = {
   label: string;
   checked: boolean;
   className?: string;
-  onChange: () => void;
+  onChange?: () => void;
+  disabled?: boolean;
   'data-testid'?: string;
 };
 
@@ -22,8 +23,11 @@ type CheckboxFieldProps = {
 export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   label,
   checked = false,
-  onChange,
+  onChange = () => {
+    /*empty*/
+  },
   className,
+  disabled = false,
   ...rest
 }) => {
   const [id] = useState(uuid());
@@ -34,6 +38,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
       data-testid={testid}
       className={className}
       onClick={() => onChange !== undefined && onChange()}
+      disabled={disabled}
     >
       <span className={`checkbox ${id}`}>{checked && <Icon name="check" />}</span>
       <label htmlFor={id}>{label}</label>
@@ -45,12 +50,12 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
 // Style
 //
 
-const CheckboxWrapper = styled.div<{ checked: boolean }>`
+const CheckboxWrapper = styled.div<{ checked: boolean; disabled: boolean }>`
   display: flex;
   align-items: center;
   width: auto;
   position: relative;
-  cursor: pointer;
+  cursor: ${(p) => (p.disabled ? 'not-allowed' : 'pointer')};
 
   label {
     display: inline-block;

--- a/src/components/Timeline/TaskListLabel.tsx
+++ b/src/components/Timeline/TaskListLabel.tsx
@@ -173,7 +173,7 @@ const StepCount = styled.span`
 
 const RowLabelContent = styled.div<{ type?: 'step' }>`
   // In case of step row, lets remove icon and caret width from total width so it aligns nicely
-  width: ${(p) => (p.type === 'step' ? 'calc(100% - 60px)' : 'calc(100% - 30px)')};
+  width: ${(p) => (p.type === 'step' ? 'calc(100% - 1.875rem - 1.875rem)' : 'calc(100% - 1.875rem - 1.875rem)')};
   display: flex;
   justify-content: space-between;
 `;

--- a/src/components/Timeline/TaskListLabel.tsx
+++ b/src/components/Timeline/TaskListLabel.tsx
@@ -212,7 +212,7 @@ const StepLabel = styled.div<{ isLoading: boolean }>`
   }
 
   svg path {
-    fill: ${(p) => (p.isLoading ? '#717171' : '#fff')};
+    fill: ${(p) => (p.isLoading ? '#717171' : undefined)};
   }
 `;
 

--- a/src/components/Timeline/TaskListLabel.tsx
+++ b/src/components/Timeline/TaskListLabel.tsx
@@ -89,7 +89,7 @@ const TaskListLabel: React.FC<Props> = (props) => {
                 tasksTotal === tasksVisible ? tasksTotal : `${tasksVisible}/${tasksTotal}`
               }`}
             >
-              {props.item.step_name}
+              <StepNameWithCount>{props.item.step_name}</StepNameWithCount>
               {!!tasksTotal && (
                 <>
                   {' '}
@@ -129,6 +129,7 @@ const RowLabel = styled.div<{ type: 'step' | 'task'; isOpen?: boolean; group?: b
   font-weight: ${(p) => (p.type === 'step' ? '600' : 'normal')};
   line-height: 1.6875rem;
   border-left: ${(p) => p.theme.border.thinLight};
+  padding-left: ${(p) => (p.type === 'task' ? '0.5rem' : undefined)};
 
   a {
     display: flex;
@@ -158,6 +159,7 @@ const RowStepName = styled.span<{ bigName: boolean }>`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  display: flex;
 `;
 
 const RowDuration = styled.span`
@@ -170,8 +172,8 @@ const StepCount = styled.span`
 `;
 
 const RowLabelContent = styled.div<{ type?: 'step' }>`
-  // In case of step row, lets remove icon width from total width so it aligns nicely
-  width: ${(p) => (p.type === 'step' ? 'calc(100% - 30px)' : '100%')};
+  // In case of step row, lets remove icon and caret width from total width so it aligns nicely
+  width: ${(p) => (p.type === 'step' ? 'calc(100% - 60px)' : 'calc(100% - 30px)')};
   display: flex;
   justify-content: space-between;
 `;
@@ -216,4 +218,10 @@ const StepLabel = styled.div<{ isLoading: boolean }>`
 
 const Padding = styled.div`
   width: 2.5rem;
+`;
+
+const StepNameWithCount = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100px;
 `;

--- a/src/components/Timeline/useTaskData.ts
+++ b/src/components/Timeline/useTaskData.ts
@@ -152,6 +152,7 @@ export function rowDataReducer(state: RowDataModel, action: RowDataAction): RowD
           }
 
           const newEndTime = !row.finished_at || endTime > row.finished_at ? endTime : row.finished_at;
+
           return {
             ...obj,
             [key]: {
@@ -164,16 +165,19 @@ export function rowDataReducer(state: RowDataModel, action: RowDataAction): RowD
           };
         }
         // New step entry
+
+        const data = grouped[key].reduce<Record<number, Task[]>>((dataobj, item) => {
+          return { ...dataobj, [item.task_id]: makeTasksForStep(dataobj, item) };
+        }, {});
+
         return {
           ...obj,
           [key]: {
             isOpen: true,
-            status: getStepStatus(grouped),
+            status: getStepStatus(data),
             finished_at: endTime,
             duration: startTime ? endTime - startTime : 0,
-            data: grouped[key].reduce<Record<number, Task[]>>((dataobj, item) => {
-              return { ...dataobj, [item.task_id]: makeTasksForStep(dataobj, item) };
-            }, {}),
+            data,
           },
         };
       }, state);

--- a/src/pages/Debug/index.tsx
+++ b/src/pages/Debug/index.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import ContentHeader from '../../components/Content/ContentHeader';
 import { ItemRow } from '../../components/Structure';
-import StatusIndicator from '../../components/Status';
 import { BigButton } from '../../components/Button';
 import FEATURE_FLAGS, { FeatureFlags } from '../../utils/FEATURE';
 import useLogger from '../../hooks/useLogger';
+import { CheckboxField } from '../../components/Form/Checkbox';
 
 const DebugPage: React.FC = () => {
   const { t } = useTranslation();
@@ -53,7 +53,7 @@ const FeatureFlagItem: React.FC<{ flag: string; active: boolean }> = ({ flag, ac
   return (
     <DebugSectionContainer>
       <DebugSectionTitle>
-        <StatusIndicator status={active ? 'completed' : 'failed'} />
+        <CheckboxField label={''} checked={active} disabled />
         {flag}
       </DebugSectionTitle>
 


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Fix for [#129 ](https://github.com/Netflix/metaflow-ui/issues/129)

The bug occurred when the row already existed in memory and the statuses were assigned to the status of the last task. As the last task was failing in this case, all steps were given a failing status.

The bug in this case was that the object passed to the function that calculated the status for a step was the wrong object. The object should have only contained the current step, instead of all the steps.

The fix was to pass the expected object to the status function.

Additionally, changes were made to the left column of the timeline to align step and task names better

<img width="344" alt="Screenshot 2023-12-15 at 11 05 25 AM" src="https://github.com/Netflix/metaflow-ui/assets/93726128/6721feb8-70d5-4a76-a5ee-842de4e91ce8">

The status of debug fields is not shown as
<img width="959" alt="Screenshot 2024-01-07 at 7 53 00 AM" src="https://github.com/Netflix/metaflow-ui/assets/93726128/cf981c01-78dc-4824-8111-70cca9e16e3b">



### Alternate Designs

\-

### Possible Drawbacks

\-

### Verification Process

Run a flow like the following, that deliberately fails on the last step

```
from metaflow import FlowSpec, step

# Welcome to your first Metaflow flow!
# To run locally: python $HOME/flows/hello_flow.py run
# To run on kubernetes: python $HOME/flows/hello_flow.py --with kubernetes run
class BorkenFlow(FlowSpec):
    @step
    def start(self):
        print("Welcome to your first flow!")
        self.next(self.a)

    @step
    def a(self):
        print("In step a")
        self.next(self.bhdfkjhsfkjhsdkfhskfjshddkjfh)

    @step
    def bhdfkjhsfkjhsdkfhskfjshddkjfh(self):
        print("In step b")
        self.next(self.c)

    @step
    def c(self):
        print("In step c")
        self.next(self.d)

    @step
    def d(self):
        print("In step d")
        self.next(self.e)

    @step
    def e(self):
        print("In step e")
        self.next(self.end)

    @step
    def end(self):
        zing = 1 / 0
        print(zing)
        pass


if __name__ == "__main__":
    BorkenFlow()
```

Go to the run page for that flow in MFGUI.
Refresh multiple times as the original bug was intermittent and only showed when the row already existed in memory.


### Release Notes

Fix for https://github.com/Netflix/metaflow-ui/issues/129 - status colors showing incorrectly