### PR TITLE
Removed code that overwrites time settings

### DIFF
--- a/src/components/Form/TimeRange.tsx
+++ b/src/components/Form/TimeRange.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import Icon from '../Icon';
 import { InputLabel } from './InputLabel';
@@ -40,14 +40,7 @@ const TimeRange: React.FC<TimeRangeProps> = ({ sectionLabel, onSubmit, initialVa
   const [selectedPreset, setPreset] = useState<string>('none');
   const { timezone } = useContext(TimezoneContext);
 
-  const startValue = initialValues && initialValues[0];
-  const endValue = initialValues && initialValues[1];
-
   useOnKeyPress('Escape', () => setShow(false));
-
-  useEffect(() => {
-    setValues({ start: startValue || null, end: endValue || null });
-  }, [startValue, endValue]);
 
   const HandleSubmit = () => {
     onSubmit({

--- a/src/hooks/useResource/__tests__/useResource.test.cypress.tsx
+++ b/src/hooks/useResource/__tests__/useResource.test.cypress.tsx
@@ -73,7 +73,6 @@ describe('useResource hook', () => {
   // Without subscribeToEvents hook should just fetch data initially
   //
   it('useResource - Basic fetch', () => {
-    console.log(server.url);
     mount(<ResourceListComponent />);
     cy.waitUntil(() => connected, {}).then(() => {
       // Check that content was fetched

--- a/src/pages/Home/Content/index.tsx
+++ b/src/pages/Home/Content/index.tsx
@@ -65,7 +65,7 @@ const HomeContentArea: React.FC<Props> = ({
           <GenericError icon="searchNotFound" message={t('error.no-results')} />
         </ItemRow>
       )}
-
+      {/* TODO */}
       <BigLoader visible={showLoader && resultAmount > 0}>
         <Spinner md />
       </BigLoader>

--- a/src/pages/Home/Home.utils.ts
+++ b/src/pages/Home/Home.utils.ts
@@ -8,7 +8,7 @@ import { defaultHomeParameters } from './useHomeParameters';
 export function makeActiveRequestParameters(params: Record<string, string>): Record<string, string> {
   const { timerange_start, timerange_end, ...rest } = params;
   let newParams = rest;
-  // We want to remove groupping from request in some cases
+  // We want to remove grouping from request in some cases
   // 1) When grouping is flow_id and only 1 flow_id filter is active, we want to show all runs of this group
   // 2) When grouping is user and only 1 user filter is active, we want to show all runs of this group
   if (newParams._group) {

--- a/src/pages/Home/Sidebar/SidebarTimerangeSelection.tsx
+++ b/src/pages/Home/Sidebar/SidebarTimerangeSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { SidebarSectionWrapper } from '.';
@@ -26,18 +26,21 @@ const SidebarTimerangeSelection: React.FC<Props> = ({ params, updateField }) => 
   const hasSelectedTimeRange = startTime || endTime;
   const { t } = useTranslation();
 
-  const shouldShowWarning = !hasSelectedTimeRange && !params.flow_id && !params._tags && !params.suer;
+  const shouldShowWarning = !hasSelectedTimeRange && !params.flow_id && !params._tags && !params.user;
+
+  const handleSubmit = ({ start, end }: { start: number | null; end: number | null }) => {
+    updateField('timerange_start', start ? start.toString() : '');
+    updateField('timerange_end', end ? end.toString() : '');
+  };
+
+  const initialValues: [number | null, number | null] = useMemo(
+    () => [startTime ? parseInt(startTime) : null, endTime ? parseInt(endTime) : null],
+    [startTime, endTime],
+  );
 
   return (
     <SidebarSectionWrapper>
-      <TimeRange
-        initialValues={[startTime ? parseInt(startTime) : null, endTime ? parseInt(endTime) : null]}
-        onSubmit={({ start, end }) => {
-          updateField('timerange_start', start ? start.toString() : '');
-          updateField('timerange_end', end ? end.toString() : '');
-        }}
-        sectionLabel="Time frame"
-      />
+      <TimeRange initialValues={initialValues} onSubmit={handleSubmit} sectionLabel="Time frame" />
 
       {hasSelectedTimeRange && (
         <ParameterList>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -171,14 +171,6 @@ const Home: React.FC = () => {
     } else if (historyAction !== 'POP' || scrollValue === 0) {
       HomeStateCache.active = true;
     }
-
-    if (historyAction !== 'POP' && initialised) {
-      if (isDefaultParams(rawParams, false, timezone)) {
-        // We want to add timerange filter if we are rolling with default params
-        // but not in back event. In back event we should keep state we had
-        setQp({ timerange_start: getTimeFromPastByDays(DEFAULT_TIME_FILTER_DAYS, timezone).toString() });
-      }
-    }
   }, [historyAction, initialised, rawParams, setQp, timezone]);
 
   // Update cache page on page change


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

The Time Range preset filters were not working. The time range was always set back to the default (30 days) after selection.

This change removes two pieces of code that reset the time range to the default.

### Alternate Designs

\-

### Possible Drawbacks

The removed code may have been deliberately added for some needed functionality. Or it could have been included to paper over race conditions and React indeterminacy.

This change does not fix existing bugs with the Back button and loaders showing when they shouldn't be.

### Verification Process

* Load the homepage
* Click on the Time Range filter
* Select `Today`
* Click on `Set`

You should see the results filtered for Today only.

The other presets can be tested in the same way.

### Release Notes

Fix bug with Time Range presets not working
