### PR TITLE
Add version to plugin URL to prevent caching

### DIFF
--- a/src/components/Plugins/PluginManager.tsx
+++ b/src/components/Plugins/PluginManager.tsx
@@ -56,7 +56,7 @@ const ALLOWED_SLOTS: AllowedSlot[] = ['task-details', 'run-header', 'header', 't
 //
 
 export function pluginPath(config: Plugin, baseurl?: string): string {
-  const path = `${config.name}/${config.config.entrypoint}`;
+  const path = `${config.name}/${config.config.entrypoint}?v=${config.config.version}`;
   return baseurl ? `${baseurl}/${path}` : apiHttp(`/plugin/${path}`);
 }
 

--- a/src/components/Plugins/__tests__/plugins.test.cypress.ts
+++ b/src/components/Plugins/__tests__/plugins.test.cypress.ts
@@ -61,17 +61,18 @@ describe('Plugins utils', () => {
   });
 
   it('pluginPath', () => {
+    const version = '1.2.3';
     expect(pluginPath(createPluginManifest())).to.equal(
-      `http://${window.location.host}/api/plugin/Plugin name/index.html`,
+      `http://${window.location.host}/api/plugin/Plugin name/index.html?v=1.0.0`,
     );
     expect(
       pluginPath(
         createPluginManifest({
           name: 'another_name',
-          config: { name: 'another_name', entrypoint: 'plugin.html', version: '0', slot: 'run-header' },
+          config: { name: 'another_name', entrypoint: 'plugin.html', version, slot: 'run-header' },
         }),
       ),
-    ).to.equal(`http://${window.location.host}/api/plugin/another_name/plugin.html`);
+    ).to.equal(`http://${window.location.host}/api/plugin/another_name/plugin.html?v=${version}`);
   });
 
   it('PluginCommuncationsAPI.isPluginMessage', () => {
@@ -122,7 +123,9 @@ describe('Plugins utils', () => {
       PluginCommunicationsAPI.isRegisterMessage({ data: { type: 'PluginRegisterEvent' } } as MessageEvent),
     ).to.equal(false);
     expect(
-      PluginCommunicationsAPI.isRegisterMessage({ data: { type: 'PluginRegisterEvent', name: 'test' } } as MessageEvent),
+      PluginCommunicationsAPI.isRegisterMessage({
+        data: { type: 'PluginRegisterEvent', name: 'test' },
+      } as MessageEvent),
     ).to.equal(false);
 
     // Correct message


### PR DESCRIPTION
### Requirements for a pull request

- [x] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Add version to the path so that the browser cache is busted and the latest plugin is always downloaded.

### Alternate Designs

A random number in the path to always bust the cache. The downside of this approach is that the HTML request would never be cached. The implemented approach will cache most of the time yet will download a new version when the version number is changed in the config for the plugin.

### Possible Drawbacks

Plugin developers may not update the version number in the config.

### Verification Process

* Ensure that the URL for the iframe for the plugin includes the version

### Release Notes

Add version to the plugin URL to bust the cache when the version changes
