### PR TITLE
Set min-height even when showing log content

### DIFF
--- a/src/pages/Task/components/SectionLoader.tsx
+++ b/src/pages/Task/components/SectionLoader.tsx
@@ -32,7 +32,7 @@ const SectionLoader: React.FC<Props> = ({ status, error, component, customNotFou
       </SectionLoaderDefaultContainer>
     );
   }
-  return component;
+  return <div style={{ minHeight: minHeight || 'unset' }}>{component}</div>;
 };
 
 //


### PR DESCRIPTION
### Requirements for a pull request

Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Set the minimum height of the log section when loading, showing errors, and showing content. This will prevent the size of the section changing when logs are loading, which caused the content below to "bounce".


### Alternate Designs

\-

### Possible Drawbacks

\-

### Verification Process

* Run a longish running flow
* Navigate to a task
* Observe the size of the log sections. They should not change until log data fills them up

### Release Notes

Set minimum height of log section
