### PR TITLE
[cards] performance optimizations

### DIFF
--- a/src/components/MFCard/DynamicCardIframe.tsx
+++ b/src/components/MFCard/DynamicCardIframe.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const DynamicCardIframe: React.FC<Props> = ({ task, hash }) => {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>();
-
+  const cacheTimestampRef = useRef<number | undefined>();
   // Get new data from the server and update the card
   const getNewData = useCallback(
     (token: string, updateFn: (payload: object) => void, iframe: HTMLIFrameElement) => {
@@ -25,12 +25,46 @@ const DynamicCardIframe: React.FC<Props> = ({ task, hash }) => {
       };
 
       fetch(`${apiHttp(taskCardsPath(task))}?invalidate=true`)
-        .then((result) => result.json())
         .then((result) => {
-          if (token === result.data?.reload_token) {
-            // Call the callback provided by the card to add new data
-            updateFn(result.data?.data);
+          if (!result.ok) {
+            throw new Error('Failed to fetch');
+          }
+          return result.json();
+        })
+        .then((result) => {
+          // check if the data attribute exists and is not null
+          // If it is null, we will retry after a timeout
+          if (result.data === null) {
+            timeoutRef.current = setTimeout(() => {
+              getNewData(token, updateFn, iframe);
+            }, DYNAMIC_CARDS_REFRESH_INTERVAL);
+            return;
+          }
 
+          // The `reload_token` controls if the card iframe itself should be reloaded since the actual card content has changed
+          // So we first check if the reload_token in the data update is the same as the reload_token present inside the card.
+          // If they are not the same then we reload the iframe.
+          if (token === result.data?.reload_token) {
+            // Every data update call for a card since Metaflow 2.11.4 will contain a `created_on` timestamp.
+            // This timestamp helps validate if the data update is newer than the previous one.
+            // This check is necessary because the data updates are best effort and may be out of order given that they are coming from the local
+            // cache in the Metaflow service.
+            if (result.data?.created_on) {
+              // The `cacheTimestampRef` helps keep track of the latest data update timestamp the UI has recieved for a particular card.
+              // If any new update has a `created_on` timestamp that is older than the latest one we have seen, we ignore it.
+              // If we update the UI with data from an older timestamp, it will appear to the user as if the UI is moving a older state from a newer state.
+              // For example : progressbars moving backwards.
+              if (cacheTimestampRef.current === undefined || cacheTimestampRef.current < result.data?.created_on) {
+                cacheTimestampRef.current = result.data?.created_on;
+                updateFn(result.data?.data);
+              }
+            } else {
+              // This code path is for older Metaflow versions that do not have the `created_on` timestamp in the data update payload.
+              // In this case, we update the card with the new data without any checks.
+              updateFn(result.data?.data);
+            }
+
+            // If the reload_token is not 'final', we continue the refresh loop
             if (!(result.data?.reload_token === 'final')) {
               timeoutRef.current = setTimeout(() => {
                 getNewData(token, updateFn, iframe);
@@ -40,8 +74,10 @@ const DynamicCardIframe: React.FC<Props> = ({ task, hash }) => {
             iframe?.contentWindow?.location.reload();
           }
         })
-        .catch((err) => {
-          console.error('Error fetching dynamic card data: ', err);
+        .catch((_) => {
+          // We deliberately ignore errors here and retry after a timeout because data update calls are best effort.
+          // data update calls may send 404's if the data is not available in the local cache or the cache is just getting populated.
+          // In such cases, we any ways retry after a timeout.
           timeoutRef.current = setTimeout(() => {
             getNewData(token, updateFn, iframe);
           }, DYNAMIC_CARDS_REFRESH_INTERVAL);
@@ -53,7 +89,7 @@ const DynamicCardIframe: React.FC<Props> = ({ task, hash }) => {
   const handleIframeLoad = (iframe: HTMLIFrameElement) => {
     const token = iframe?.contentWindow?.METAFLOW_RELOAD_TOKEN;
     const updateFn = iframe?.contentWindow?.metaflow_card_update;
-
+    cacheTimestampRef.current = -1;
     // If the card supplies a reload token and an update function, start the refresh loop
     if (updateFn && token) {
       timeoutRef.current = setTimeout(() => {

--- a/src/components/MFCard/useTaskCards.ts
+++ b/src/components/MFCard/useTaskCards.ts
@@ -4,7 +4,7 @@ import { DataModel } from '../../hooks/useResource';
 import { Task } from '../../types';
 import { Decorator } from '../DAG/DAGUtils';
 
-const POSTLOAD_POLL_INTERVAL = 5000;
+const POSTLOAD_POLL_INTERVAL = 500;
 
 type CardResultState = 'loading' | 'timeout' | 'success' | 'error';
 export type CardDefinition = {
@@ -112,10 +112,9 @@ export default function useTaskCards(task: Task | null, decorators: Decorator[])
   // Poll for new cards
   useEffect(() => {
     let t: number;
+
     // Check if polling is activated (activated after finished requests).
     if (poll) {
-      // Timeout timer is: task.finished_at + timeout from decorator attributes + 30seconds extra time.
-      const timeout = taskFinishedAt ? taskFinishedAt + (maxTimeout + 30) * 1000 : false;
       // if we have enough cards (as presented by decorators list) or timeout has passed, skip request.
       if (expectedCards.length <= taskCards[url]?.cards.length) {
         setPoll(false);
@@ -126,14 +125,6 @@ export default function useTaskCards(task: Task | null, decorators: Decorator[])
           }));
         }
         // If the timeout has been reached
-      } else if (timeout && timeout < Date.now()) {
-        setPoll(false);
-        if (taskCards[url]?.status !== 'timeout') {
-          setTaskCards((prev) => ({
-            ...prev,
-            [url]: { cards: prev[url]?.cards ?? [], status: 'timeout' },
-          }));
-        }
       } else {
         // Otherwise set the status to loading and continue polling
         if (taskCards[url]?.status !== 'loading') {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,4 +58,4 @@ export const DEFAULT_TIME_FILTER_DAYS: number =
 export const DYNAMIC_CARDS_REFRESH_INTERVAL =
   process.env.REACT_APP_DYNAMIC_CARDS_REFRESH_INTERVAL !== undefined
     ? Number(process.env.REACT_APP_DYNAMIC_CARDS_REFRESH_INTERVAL)
-    : 2000;
+    : 400;


### PR DESCRIPTION
- make refresh interval default smaller
- remove timeout code block in card load
- leveraging the `created_on` timestamps in dataupdates to discard stale data
- handle case of idle refresh

### Requirements for a pull request

Changes compatible with : https://github.com/Netflix/metaflow-service/pull/417