### PR TITLE
Scroll to active index in task list

### DIFF
--- a/src/pages/Task/components/TaskList.tsx
+++ b/src/pages/Task/components/TaskList.tsx
@@ -54,6 +54,11 @@ const TaskList: React.FC<Props> = ({
       (viewScrollTop + 25 > ref.current.offsetTop ? HEADER_SIZE_PX + 25 : ref.current.offsetTop - viewScrollTop + 25)
     : 0;
 
+  // Get the index of the active task so that the list can scroll to it
+  const activeIndex = rows.findIndex(
+    (item) => item.type === 'task' && item.data[0].step_name + '/' + getTaskId(item.data[0]) === activeTask,
+  );
+
   const rowRenderer = useCallback(
     ({ index, style }: { index: number; style: CSSProperties }) => {
       const item = rows[index];
@@ -95,6 +100,8 @@ const TaskList: React.FC<Props> = ({
             rowRenderer={rowRenderer}
             height={listSize}
             width={toRelativeSize(245)}
+            scrollToIndex={activeIndex}
+            scrollToAlignment="center"
           />
         )}
 


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

> I don’t know if this is just me but if you have a long list of tasks and you are in the timeline view and then select a task to view in the task view, while it remembers what task you selected it presents the list of task back at the top (so if you selected something after scrolling, you have to scroll again to get to it. It doesn’t do this when you are already in task view

This change scrolls the list so that the active task is visible in the task list.

https://github.com/Netflix/metaflow-ui/assets/93726128/8b558d8b-6517-4f23-ac30-3b3584ffcc18

### Alternate Designs

I considered capturing the index of the clicked task when it was clicked in the timeline view, storing that value somewhere, and using that value to scroll to the correct place in the task list. The approach that I used was simpler.

### Possible Drawbacks

The task won't be in the same position as when it was clicked.

### Verification Process

* Find a run with lots of tasks
* Click on a task in the timeline view
* Verify that the task is visible and highlighted in the task list

### Release Notes

Scroll to task position when task is clicked in the timeline view