### PR TITLE
Bug/event trigger

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,26 +5,26 @@ We follow [Semantic Versioning Specification 2.0.0](https://semver.org/spec/v2.0
 In short, given a version number MAJOR.MINOR.PATCH, increment the:
 
 1. MAJOR version when you make incompatible API changes,
-2. MINOR version when you add functionality in a backwards compatible manner, and
-3. PATCH version when you make backwards compatible bug fixes.
+2. MINOR version when you add functionality in a backward-compatible manner, and
+3. PATCH version when you make backward-compatible bug fixes.
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
 ## Shipping a new version
 
-The release process is mostly automated via Github Actions, however a few manual steps are required:
+The release process is mostly automated via Github Actions however, a few manual steps are required:
 
 - [ ] [Edit `package.json`](https://github.com/Netflix/metaflow-ui/edit/master/package.json) version in `master` branch (e.g. `"version": "1.0.0"`)
-- [ ] Add and commit the changes to `package.json`
-- [ ] Create new tag from `master` branch (e.g. `git tag v1.0.0`, note the `v` -prefix)
+- [ ] Add, commit, and push the changes to `package.json`
+- [ ] Create a new tag from `master` branch (e.g. `git tag v1.0.0`, note the `v` -prefix)
 - [ ] Push tag to remote (e.g. `git push origin v1.0.0`)
 - [ ] [Package job](https://github.com/Netflix/metaflow-ui/actions/workflows/package.yml) is triggered, wait for it to finish
-- [ ] New [release draft](https://github.com/Netflix/metaflow-ui/releases) is automatically created via Github Actions
+- [ ] A new [release draft](https://github.com/Netflix/metaflow-ui/releases) is automatically created via Github Actions
 - [ ] Edit release draft
-  - [ ] Make sure current and previous version are correct
+  - [ ] Make sure the current and previous versions are correct
   - [ ] Edit `Compatibility` section (Correct [Netflix/metaflow-service](https://github.com/Netflix/metaflow-service/releases) release versions)
   - [ ] Edit/remove `Additional resources` section
-  - [ ] Make sure release artifact is uploaded
+  - [ ] Make sure the release artifact is uploaded
 - [ ] Publish release draft
 
 - [ ] Follow the [metaflow-service release docs](https://github.com/Netflix/metaflow-service/blob/master/RELEASE.md) to set the UI version and publish to dockerhub

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaflow-ui",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "private": true,
   "dependencies": {
     "@rehooks/component-size": "^1.0.3",

--- a/src/components/Trigger/__tests__/Trigger.test.cypress.tsx
+++ b/src/components/Trigger/__tests__/Trigger.test.cypress.tsx
@@ -30,4 +30,23 @@ describe('Trigger test', () => {
       .should('have.attr', 'href', `/${basename}/${flow_name}/${run_id}`)
       .and('contain', 'HelloFlow/...flow-atykf');
   });
+
+  it('Shows non-run event', () => {
+    mount(
+      <ThemeProvider theme={theme}>
+        <Router basename={basename}>
+          <Trigger
+            triggerEventsValue={{
+              name: 'document_classification',
+              timestamp: '1663184739',
+              id: '6523f2a6-694a-415d-9ec6-9483afbc7903',
+              type: 'event',
+            }}
+          />
+        </Router>
+      </ThemeProvider>,
+    );
+
+    cy.get('div').should('contain', 'document_classification');
+  });
 });

--- a/src/components/Trigger/index.tsx
+++ b/src/components/Trigger/index.tsx
@@ -45,11 +45,16 @@ const Trigger: React.FC<Props> = ({ triggerEventsValue, className, showToolTip =
 
   return (
     <TriggerLine key={id} data-tip data-for={tooltipId} className={className}>
-      {link && (
+      {link ? (
         <TriggerLink to={link}>
           <StyledIcon name="arrow" linkToRun={linkToRun} />
           {showToolTip ? displayLabel : id}
         </TriggerLink>
+      ) : (
+        <>
+          <StyledIcon name="arrow" linkToRun={linkToRun} />
+          {showToolTip ? displayLabel : id}
+        </>
       )}
       {showToolTip && <Tooltip id={tooltipId}>{label}</Tooltip>}
     </TriggerLine>


### PR DESCRIPTION
### Requirements for a pull request

- [x] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [x] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

Re-added label for non-run event triggers.

<img width="188" alt="Screenshot 2024-05-13 at 7 45 12 AM" src="https://github.com/Netflix/metaflow-ui/assets/93726128/17cca3b0-57e0-46bf-8ffc-a836b74997f3">


### Alternate Designs

\-

### Possible Drawbacks

\-

### Verification Process

* Trigger a run with an event.
* Go to MFGUI for that run
* Verify that the event is shown on the run header bar

### Release Notes

Re-add non-run event label
