### PR TITLE
fix: disable dropdown multiline wrapping

### DIFF
--- a/src/components/Form/Dropdown.tsx
+++ b/src/components/Form/Dropdown.tsx
@@ -93,6 +93,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
               style={{
                 width: '100%',
                 textAlign: 'left',
+                whiteSpace: 'nowrap',
               }}
             >
               {labelRenderer ? labelRenderer(activeOption[0], activeOption[1]) : activeOption[1]}


### PR DESCRIPTION
Fix dropdowns going multiline when they should not.
