### PR TITLE
fix: task status indicator not updating live in task view sidebar

### DIFF
--- a/src/pages/Task/components/TaskList.tsx
+++ b/src/pages/Task/components/TaskList.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { List } from 'react-virtualized';
+import { List as VirtualList } from 'react-virtualized';
 import styled from 'styled-components';
 import { AsyncStatus } from '@/types';
 import TaskListRow from '@pages/Task/components/TaskListRow';
@@ -37,16 +37,25 @@ const TaskList: React.FC<Props> = ({
 }) => {
   const [viewScrollTop, setScrollTop] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
+  const listRef = useRef<VirtualList>(null);
   const { t } = useTranslation();
 
+  // Track scroll position so we can recalculate how tall the list should be
+  // depending on whether the sticky app header is visible or not.
   useEffect(() => {
-    const listener = () => {
-      setScrollTop(window.scrollY);
-    };
-
-    window.addEventListener('scroll', listener);
-    return () => window.removeEventListener('scroll', listener);
+    const onScroll = () => setScrollTop(window.scrollY);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
   }, []);
+
+  // When task data changes (e.g. a running task finishes), react-virtualized
+  // won't automatically re-render already-visible rows because it caches them.
+  // Calling forceUpdateGrid() tells it to throw away that cache and re-render
+  // every visible row with the latest data, which is how the status indicator
+  // next to each task name stays up to date without needing a page reload.
+  useEffect(() => {
+    listRef.current?.forceUpdateGrid();
+  }, [rows]);
 
   const listSize = ref?.current
     ? window.innerHeight -
@@ -92,7 +101,8 @@ const TaskList: React.FC<Props> = ({
     <TaskListContainer ref={ref}>
       <FixedList style={{ position: 'sticky', top: 'var(--layout-application-bar-height)' }}>
         {rows.length > 0 && (
-          <List
+          <VirtualList
+            ref={listRef}
             overscanRowCount={5}
             rowCount={rows.length}
             rowHeight={toRelativeSize(28)}


### PR DESCRIPTION
## What this fixes

Closes #80 (from upstream Netflix/metaflow-ui)

When viewing a task in the task view, the status indicator (the colored line next to each task name in the left sidebar) was not updating in real time as tasks finished. You had to reload the page to see the updated status, even though the timeline view updated correctly.

## Root cause

[TaskList.tsx](cci:7://file:///home/kdmaster/Gsoc/metaflow-ui/src/pages/Task/components/TaskList.tsx:0:0-0:0) uses react-virtualized's `<List>` component to render the sidebar task rows. react-virtualized aggressively caches row renders for performance — when task data updates arrive via WebSocket and the `rows` prop changes, the component sees new props but react-virtualized does **not** automatically re-render already-visible rows with the fresh data.

The old code had a `window.scroll` listener that called `setScrollTop()` on every scroll event. This worked as an accidental workaround — scrolling forced a re-render, which flushed the row cache and showed updated statuses. But if the user never scrolled, the status would never update.

## Fix

Added a `ref` on the `<List>` component and call `forceUpdateGrid()` inside a `useEffect` that fires whenever `rows` changes:

```tsx
useEffect(() => {
  listRef.current?.forceUpdateGrid();
}, [rows]);
