### PR TITLE
docs: Add WSL2 local development setup guide (resolves #158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,152 +56,40 @@ METAFLOW_HEAD='<meta name="keywords" content="metaflow" />'
 
 See [docs/plugin-system.md](docs/plugin-system.md) to get started with plugins development.
 
-## Running Metaflow UI on WSL2
+## Local Development
 
-> **Resolves [Issue #158](https://github.com/Netflix/metaflow-ui/issues/158)** — Step-by-step guide to running Metaflow UI inside WSL2 (Ubuntu).
+**Requirements:** Node.js 18.x, Yarn 1.x, Docker (for running the backend locally).
 
-### Prerequisites
+On Windows, use WSL2 (Ubuntu) — the steps below apply to Linux/macOS and WSL2 environments.
 
-| Requirement | Version | Notes |
-|---|---|---|
-| Windows 10/11 | 21H2 or later | WSL2 must be enabled |
-| WSL2 + Ubuntu | Ubuntu 20.04 / 22.04 | Run `wsl --install` in PowerShell if not installed |
-| Node.js | **18.x (LTS)** | Installed via `nvm` inside WSL2 |
-| Yarn | 1.x | Installed globally via `npm` |
-| Docker Desktop | Latest | Required only if running the backend (Metaflow Service) locally |
-
-> ⚠️ **Important:** All commands below must be run **inside your WSL2 terminal** (not PowerShell or CMD). Clone and work with the repository under the Linux home directory (e.g. `~/`) — **not** under `/mnt/c/...`. Working under `/mnt/c/` causes severe filesystem performance degradation and may break `yarn install`.
-
----
-
-### Installation
-
-#### 1. Open WSL2
-
-```bash
-# In Windows: Start → "Ubuntu" or run in PowerShell:
-wsl
-```
-
-#### 2. Install Node 18 via nvm
-
-```bash
-# Install nvm
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-
-# Reload shell (or open a new terminal)
-source ~/.bashrc
-
-# Install and use Node 18
-nvm install 18
-nvm use 18
-nvm alias default 18
-
-# Verify
-node -v   # should print v18.x.x
-npm -v
-```
-
-#### 3. Install Yarn globally
-
-```bash
-npm install -g yarn
-
-# Verify
-yarn -v   # should print 1.x.x
-```
-
-#### 4. Clone the repository inside the Linux filesystem
-
-```bash
-# Clone into your Linux home directory (NOT under /mnt/c)
-cd ~
-git clone https://github.com/Netflix/metaflow-ui.git
-cd metaflow-ui
-```
-
-#### 5. Install dependencies
+### Install dependencies
 
 ```bash
 yarn install
 ```
 
-If you see peer dependency warnings, you can safely ignore them. If you encounter an `ENOSPC` (inotify limit) error:
-
-```bash
-echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
-sudo sysctl -p
-```
-
-Then re-run `yarn install`.
-
----
-
-### Running the Development Server
-
-#### Start the UI (with the default proxy)
+### Start the development server
 
 ```bash
 yarn start
 ```
 
-This starts the development server at **[http://localhost:3000](http://localhost:3000)**.
-
-The UI expects a running [Metaflow Service](https://github.com/Netflix/metaflow-service) backend at `http://localhost:8083` by default. You can customize this:
+The app will be available at [http://localhost:3000](http://localhost:3000). It expects a running [Metaflow Service](https://github.com/Netflix/metaflow-service) backend at `http://localhost:8083` by default. You can customize this:
 
 ```bash
-# Point the dev proxy to a custom backend URL
+# Use a custom backend URL via proxy
 METAFLOW_SERVICE_PROXY=http://localhost:8083 yarn start
 
-# Bypass the proxy and talk directly to the backend (useful if proxy causes issues)
+# Or talk directly to the backend (bypasses proxy)
 REACT_APP_METAFLOW_SERVICE=http://localhost:8083 yarn start
-
-# Customize the WebSocket endpoint separately
-REACT_APP_METAFLOW_SERVICE_WS=ws://localhost:8083 yarn start
 ```
 
-#### Start the backend (Metaflow Service) via Docker
-
-In a separate WSL2 terminal:
+### Start the backend
 
 ```bash
-cd ~
-git clone https://github.com/Netflix/metaflow-service.git
-cd metaflow-service
-
-# Start the backend (recommended for development)
+git clone https://github.com/Netflix/metaflow-service.git && cd metaflow-service
 docker-compose -f docker-compose.development.yml up
 ```
-
-This exposes the Metaflow Service API on port **8083** and the metadata service on port **8080**.
-
-#### Access the UI
-
-Open your Windows browser and navigate to:
-
-```
-http://localhost:3000
-```
-
-WSL2 automatically forwards ports, so `localhost` works directly from Windows.
-
----
-
-### Troubleshooting
-
-| Problem | Cause | Fix |
-|---|---|---|
-| `yarn start` hangs or crashes | Repository cloned under `/mnt/c/` | Move the repo to `~/metaflow-ui` inside WSL2 |
-| `ENOSPC: no space left` or inotify error | Linux inotify watch limit too low | Run `echo fs.inotify.max_user_watches=524288 \| sudo tee -a /etc/sysctl.conf && sudo sysctl -p` |
-| `command not found: yarn` | Yarn not installed or nvm not loaded | Run `source ~/.bashrc`, then `npm install -g yarn` |
-| `command not found: nvm` | nvm not loaded in current shell | Run `source ~/.bashrc` or open a new terminal |
-| UI loads but shows no data / all requests fail | Backend not running | Start Metaflow Service: `docker-compose -f docker-compose.development.yml up` inside `metaflow-service/` |
-| `ERR_CONNECTION_REFUSED` on port 8083 | Docker Desktop WSL2 integration disabled | In Docker Desktop → Settings → Resources → WSL Integration → enable your Ubuntu distro |
-| CORS errors in browser console | UI talking directly to backend without proxy | Use `METAFLOW_SERVICE_PROXY=http://localhost:8083 yarn start` instead of `REACT_APP_METAFLOW_SERVICE` |
-| `node: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.28' not found` | Wrong Node version for your Ubuntu | Use `nvm install 18 && nvm use 18` |
-| Port 3000 already in use | Another process is using the port | Run `lsof -ti:3000 | xargs kill -9`, then retry `yarn start` |
-
----
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,153 @@ METAFLOW_HEAD='<meta name="keywords" content="metaflow" />'
 
 See [docs/plugin-system.md](docs/plugin-system.md) to get started with plugins development.
 
+## Running Metaflow UI on WSL2
+
+> **Resolves [Issue #158](https://github.com/Netflix/metaflow-ui/issues/158)** — Step-by-step guide to running Metaflow UI inside WSL2 (Ubuntu).
+
+### Prerequisites
+
+| Requirement | Version | Notes |
+|---|---|---|
+| Windows 10/11 | 21H2 or later | WSL2 must be enabled |
+| WSL2 + Ubuntu | Ubuntu 20.04 / 22.04 | Run `wsl --install` in PowerShell if not installed |
+| Node.js | **18.x (LTS)** | Installed via `nvm` inside WSL2 |
+| Yarn | 1.x | Installed globally via `npm` |
+| Docker Desktop | Latest | Required only if running the backend (Metaflow Service) locally |
+
+> ⚠️ **Important:** All commands below must be run **inside your WSL2 terminal** (not PowerShell or CMD). Clone and work with the repository under the Linux home directory (e.g. `~/`) — **not** under `/mnt/c/...`. Working under `/mnt/c/` causes severe filesystem performance degradation and may break `yarn install`.
+
+---
+
+### Installation
+
+#### 1. Open WSL2
+
+```bash
+# In Windows: Start → "Ubuntu" or run in PowerShell:
+wsl
+```
+
+#### 2. Install Node 18 via nvm
+
+```bash
+# Install nvm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
+# Reload shell (or open a new terminal)
+source ~/.bashrc
+
+# Install and use Node 18
+nvm install 18
+nvm use 18
+nvm alias default 18
+
+# Verify
+node -v   # should print v18.x.x
+npm -v
+```
+
+#### 3. Install Yarn globally
+
+```bash
+npm install -g yarn
+
+# Verify
+yarn -v   # should print 1.x.x
+```
+
+#### 4. Clone the repository inside the Linux filesystem
+
+```bash
+# Clone into your Linux home directory (NOT under /mnt/c)
+cd ~
+git clone https://github.com/Netflix/metaflow-ui.git
+cd metaflow-ui
+```
+
+#### 5. Install dependencies
+
+```bash
+yarn install
+```
+
+If you see peer dependency warnings, you can safely ignore them. If you encounter an `ENOSPC` (inotify limit) error:
+
+```bash
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
+```
+
+Then re-run `yarn install`.
+
+---
+
+### Running the Development Server
+
+#### Start the UI (with the default proxy)
+
+```bash
+yarn start
+```
+
+This starts the development server at **[http://localhost:3000](http://localhost:3000)**.
+
+The UI expects a running [Metaflow Service](https://github.com/Netflix/metaflow-service) backend at `http://localhost:8083` by default. You can customize this:
+
+```bash
+# Point the dev proxy to a custom backend URL
+METAFLOW_SERVICE_PROXY=http://localhost:8083 yarn start
+
+# Bypass the proxy and talk directly to the backend (useful if proxy causes issues)
+REACT_APP_METAFLOW_SERVICE=http://localhost:8083 yarn start
+
+# Customize the WebSocket endpoint separately
+REACT_APP_METAFLOW_SERVICE_WS=ws://localhost:8083 yarn start
+```
+
+#### Start the backend (Metaflow Service) via Docker
+
+In a separate WSL2 terminal:
+
+```bash
+cd ~
+git clone https://github.com/Netflix/metaflow-service.git
+cd metaflow-service
+
+# Start the backend (recommended for development)
+docker-compose -f docker-compose.development.yml up
+```
+
+This exposes the Metaflow Service API on port **8083** and the metadata service on port **8080**.
+
+#### Access the UI
+
+Open your Windows browser and navigate to:
+
+```
+http://localhost:3000
+```
+
+WSL2 automatically forwards ports, so `localhost` works directly from Windows.
+
+---
+
+### Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| `yarn start` hangs or crashes | Repository cloned under `/mnt/c/` | Move the repo to `~/metaflow-ui` inside WSL2 |
+| `ENOSPC: no space left` or inotify error | Linux inotify watch limit too low | Run `echo fs.inotify.max_user_watches=524288 \| sudo tee -a /etc/sysctl.conf && sudo sysctl -p` |
+| `command not found: yarn` | Yarn not installed or nvm not loaded | Run `source ~/.bashrc`, then `npm install -g yarn` |
+| `command not found: nvm` | nvm not loaded in current shell | Run `source ~/.bashrc` or open a new terminal |
+| UI loads but shows no data / all requests fail | Backend not running | Start Metaflow Service: `docker-compose -f docker-compose.development.yml up` inside `metaflow-service/` |
+| `ERR_CONNECTION_REFUSED` on port 8083 | Docker Desktop WSL2 integration disabled | In Docker Desktop → Settings → Resources → WSL Integration → enable your Ubuntu distro |
+| CORS errors in browser console | UI talking directly to backend without proxy | Use `METAFLOW_SERVICE_PROXY=http://localhost:8083 yarn start` instead of `REACT_APP_METAFLOW_SERVICE` |
+| `node: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.28' not found` | Wrong Node version for your Ubuntu | Use `nvm install 18 && nvm use 18` |
+| Port 3000 already in use | Another process is using the port | Run `lsof -ti:3000 | xargs kill -9`, then retry `yarn start` |
+
+---
+
 ## Documentation
 
 See [docs/README.md](docs/README.md) to learn more.


### PR DESCRIPTION
## Summary

Adds a comprehensive step-by-step guide for setting up and running Metaflow UI locally inside WSL2 (Ubuntu), resolving #158.

## Changes

- **README.md**: New section `## Running Metaflow UI on WSL2`
  - Prerequisites table (OS, WSL2, Node 18, Yarn, Docker Desktop)
  - Installation: nvm → Node 18 → Yarn → clone → yarn install
  - Running the dev server with `yarn start` and all env var options
  - Backend setup via `docker-compose -f docker-compose.development.yml up`
  - Troubleshooting table covering 9 common issues with causes and fixes

## Why This Change

Issue #158 reports that users cannot set up Metaflow UI on WSL2 because no WSL2-specific guidance exists. The existing docs assume Linux/macOS without acknowledging WSL2 gotchas (filesystem placement, inotify limits, port forwarding, Docker integration).

## No Logic Changes

This PR is documentation-only. No source files, configuration, or application logic were modified.

Closes #158