### PR TITLE
fix: MSW mock endpoint mismatch when dev server runs on non-3000 ports

### DIFF
--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -2,7 +2,7 @@ import { HttpResponse, http, ws } from 'msw';
 import { setupWorker } from 'msw/browser';
 
 const stantardGetEndpoint = (endpoint, data) => {
-  const url = `http://localhost:3000/${endpoint}`;
+  const url = `${window.location.origin}/${endpoint}`;
 
   return http.get(url, () => {
     return HttpResponse.json({
@@ -22,13 +22,15 @@ const stantardGetEndpoint = (endpoint, data) => {
   });
 };
 
-const rawGetEndpoint = (url, data) => {
+const rawGetEndpoint = (endpoint, data) => {
+  const url = `${window.location.origin}/${endpoint}`;
   return http.get(url, () => {
     return HttpResponse.json(data);
   });
 };
 
-const wsApi = ws.link('ws://localhost:3000/api/ws');
+const wsOrigin = window.location.origin.replace(/^http/, 'ws');
+const wsApi = ws.link(`${wsOrigin}/api/ws`);
 
 export const worker = setupWorker(
   stantardGetEndpoint('api/runs', [


### PR DESCRIPTION
### Description of the Change

The mock API setup in src/mocks/browser.js previously hardcoded the base URL to:

`http://localhost:3000`

This caused issues when the React development server started on a different port (e.g. 3001 or 3002) because Mock Service Worker (MSW) intercepts did not match the request origin.

As a result, the mock endpoints failed to intercept API requests during local development.

This change replaces the hardcoded origin with:

`window.location.origin`

This allows the mock endpoints to dynamically match the current origin of the running application, ensuring that MSW intercepts work regardless of the port used by the development server.

### Alternate Designs

Other alternatives considered:

Using a configurable environment variable for the mock base URL.

Detecting the dev server port and dynamically constructing the URL.

However, using `window.location.origin` was chosen because it is simpler, requires no configuration, and ensures the mock endpoints always match the current application origin.

### Possible Drawbacks

None expected. The change only affects local mock endpoint construction and should not impact production behavior.

### Verification Process

Steps used to verify the fix:

Started the development server while port 3000 was already in use.

Dev server started on http://localhost:3002.

Observed that mock API requests failed due to the hardcoded localhost:3000 endpoint.

Updated the mock endpoint to use window.location.origin.

Restarted the dev server.

Verified that all mock requests were correctly intercepted by MSW.

### Result

Mock API responses were correctly returned regardless of the dev server port. Fixes #177 

<img width="1416" height="966" alt="Screenshot 2026-03-14 at 5 11 49 AM" src="https://github.com/user-attachments/assets/c483cf47-47b5-46ad-9445-72850806f665" />

<img width="1416" height="966" alt="Screenshot 2026-03-14 at 5 12 17 AM" src="https://github.com/user-attachments/assets/c991eb11-75b3-4fe7-99aa-e20c9fae68e0" />


