### PR TITLE
Persist timeline expand/collapse state in URL

### DIFF
--- a/cypress/integration/run_details.js
+++ b/cypress/integration/run_details.js
@@ -21,9 +21,18 @@ const MOCK_STEPS = [
     user_name: 'SanteriCM',
     ts_epoch: 1595574762958,
     tags: ['testingtag'],
-    system_tags: ['user:SanteriCM', ],
-  }
-]
+    system_tags: ['user:SanteriCM'],
+  },
+  {
+    flow_id: 'BasicFlow',
+    run_number: 1,
+    step_name: 'end',
+    user_name: 'SanteriCM',
+    ts_epoch: 1595574763000,
+    tags: ['testingtag'],
+    system_tags: ['user:SanteriCM'],
+  },
+];
 
 const MOCK_TASKS = [
   {
@@ -41,8 +50,24 @@ const MOCK_TASKS = [
     attempt_id: 0,
     tags: ['testingtag'],
     system_tags: ['user:SanteriCM', 'runtime:dev', 'python_version:3.7.6', 'date:2020-07-24', 'metaflow_version:2.0.5'],
-  }
-]
+  },
+  {
+    flow_id: 'BasicFlow',
+    run_number: 1,
+    step_name: 'end',
+    task_id: 2,
+    task_name: '2',
+    status: 'completed',
+    user_name: 'SanteriCM',
+    ts_epoch: 1595574763001,
+    finished_at: 1595574763021,
+    started_at: 1595574763001,
+    duration: 20,
+    attempt_id: 0,
+    tags: ['testingtag'],
+    system_tags: ['user:SanteriCM', 'runtime:dev', 'python_version:3.7.6', 'date:2020-07-24', 'metaflow_version:2.0.5'],
+  },
+];
 
 describe('Rundetails', () => {
   beforeEach(() => {
@@ -179,5 +204,54 @@ describe('Rundetails', () => {
       .then(() => {
         cy.get('[data-testid="option-overview"]').click();
       });
+  });
+
+  describe('open_steps URL persistence', () => {
+    const navigateToTimeline = () => {
+      cy.get('[data-testid="result-group-row"]').first().click();
+      cy.wait('@TaskData');
+      cy.wait('@StepData');
+      cy.get('[data-testid="tab-heading-item"]').eq(1).contains('Timeline').click();
+    };
+
+    it('collapsing a step updates the URL to include open_steps with the open step names', () => {
+      navigateToTimeline();
+      cy.contains('[data-testid="tasklistlabel-step-container"]', 'start').click();
+      cy.location('search').then((search) => {
+        const params = new URLSearchParams(search);
+        expect(params.get('open_steps')).to.equal('end');
+      });
+    });
+
+    it('expanding all steps removes the open_steps param from the URL', () => {
+      navigateToTimeline();
+      // Collapse all, then expand all
+      cy.get('[data-testid="timeline-collapse-button"]').click();
+      cy.location('search').then((search) => {
+        const params = new URLSearchParams(search);
+        expect(params.get('open_steps')).to.exist;
+      });
+      cy.get('[data-testid="timeline-collapse-button"]').click();
+      cy.location('search').then((search) => {
+        const params = new URLSearchParams(search);
+        expect(params.get('open_steps')).to.be.null;
+      });
+    });
+
+    it('loading a URL with ?open_steps=stepName shows only that step expanded', () => {
+      cy.intercept({ method: 'GET', url: '**/dag*' }, (req) => {
+        req.reply({ statusCode: 200, body: { data: { steps: {}, graph_structure: [] } } });
+      });
+      cy.visit('/BasicFlow/1/view/timeline?open_steps=start');
+      cy.wait('@TaskData');
+      cy.wait('@StepData');
+      // "start" should be expanded (icon rotate=0), "end" should be collapsed (icon rotate=-90)
+      cy.contains('[data-testid="tasklistlabel-step-container"]', 'start').within(() => {
+        cy.get('[data-testid="tasklistlabel-open-icon"]').should('have.attr', 'rotate', '0');
+      });
+      cy.contains('[data-testid="tasklistlabel-step-container"]', 'end').within(() => {
+        cy.get('[data-testid="tasklistlabel-open-icon"]').should('have.attr', 'rotate', '-90');
+      });
+    });
   });
 });

--- a/src/components/Plugins/PluginRegisterSystem.tsx
+++ b/src/components/Plugins/PluginRegisterSystem.tsx
@@ -15,10 +15,9 @@ const PluginRegisterSystem: React.FC<{ baseurl?: string }> = ({ baseurl }) => {
   useEffect(() => {
     // Fetch Plugin definitions
     fetch(apiHttp('/plugin'))
-      .then((response) => {
-        return response.json();
-      })
-      .then((plugins: Plugin[]) => {
+      .then((response) => response.json())
+      .then((data: Plugin[] | { data?: Plugin[] }) => {
+        const plugins = Array.isArray(data) ? data : data?.data ?? [];
         setDefinitions(plugins);
       })
       .catch((e) => console.log(e));
@@ -46,7 +45,8 @@ const PluginRegisterSystem: React.FC<{ baseurl?: string }> = ({ baseurl }) => {
 
   // Filter out already registered plugin so their iframes will be destroyed.
   const registeredPlugins = plugins.map((item) => item.name);
-  const toRegister = definitions.filter((item) => registeredPlugins.indexOf(item.name) === -1);
+  const definitionsList = Array.isArray(definitions) ? definitions : [];
+  const toRegister = definitionsList.filter((item) => registeredPlugins.indexOf(item.name) === -1);
 
   return (
     <HidingElement>

--- a/src/components/Timeline/useTaskListSettings.ts
+++ b/src/components/Timeline/useTaskListSettings.ts
@@ -90,6 +90,7 @@ export type TaskSettingsQueryParameters = {
   direction: QueryParamConfig<string | null | undefined, string | null | undefined>;
   steps: QueryParamConfig<string | null | undefined, string | null | undefined>;
   status: QueryParamConfig<string | null | undefined, string | null | undefined>;
+  open_steps: QueryParamConfig<string | null | undefined, string | null | undefined>;
 };
 
 export type TaskSettingsParametersMap = DecodedValueMap<TaskSettingsQueryParameters>;
@@ -158,6 +159,7 @@ export default function useTaskListSettings(): TaskSettingsHook {
     direction: StringParam,
     steps: StringParam,
     status: StringParam,
+    open_steps: StringParam,
   });
 
   useEffect(() => {
@@ -194,13 +196,13 @@ export default function useTaskListSettings(): TaskSettingsHook {
 
     // Check if we were in custom mode, if so we need to save change to localstorage as well
     if (taskListSettings.isCustomEnabled) {
-      const { steps, ...rest } = q;
+      const { steps, open_steps, ...rest } = q;
       localStorage.setItem('custom-settings', JSON.stringify(rest));
     } else {
       // If we changed something and we now differ from default settings, we need to set
       // custom mode on and start saving settingin localstorage
       if (!equalsDefaultMode(q.order, q.direction, q.status, q.group)) {
-        const { steps, ...rest } = q;
+        const { steps, open_steps, ...rest } = q;
 
         dispatch({ type: 'setCustom', value: true });
         localStorage.setItem('custom-settings', JSON.stringify(rest));
@@ -239,7 +241,8 @@ export default function useTaskListSettings(): TaskSettingsHook {
           const parsed = JSON.parse(previousSettings);
           if (parsed) {
             const steps = q.steps ? { steps: q.steps } : {};
-            sq({ ...parsed, ...steps }, 'replace');
+            const openSteps = q.open_steps ? { open_steps: q.open_steps } : {};
+            sq({ ...parsed, ...steps, ...openSteps }, 'replace');
           }
         }
       }

--- a/src/pages/Run/RunPage.tsx
+++ b/src/pages/Run/RunPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Run as IRun, Metadata } from '@/types';
@@ -120,6 +120,81 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
 
   const urlParams = new URLSearchParams(cleanParametersMap(listParams)).toString();
 
+  const lastOpenStepsFromUrlRef = useRef<string | null>(null);
+  const isInitializedRef = useRef(false);
+  const lastKnownStepNamesRef = useRef<Set<string>>(new Set());
+
+  // Keep URL in sync with which steps are expanded. On load, read from URL. Then when user toggles, write to URL.
+  useEffect(() => {
+    dispatch({ type: 'reset' });
+    lastOpenStepsFromUrlRef.current = null;
+    isInitializedRef.current = false;
+    lastKnownStepNamesRef.current = new Set();
+  }, [params.runNumber, dispatch]);
+
+  useEffect(() => {
+    const visibleStepNames = Object.keys(rows).filter((k) => !k.startsWith('_'));
+    if (visibleStepNames.length === 0) return;
+
+    const visibleSet = new Set(visibleStepNames);
+    const lastKnown = lastKnownStepNamesRef.current;
+    const hasNewSteps = visibleSet.size !== lastKnown.size || !visibleStepNames.every((n) => lastKnown.has(n));
+
+    const applyUrlToState = () => {
+      const urlOpenSteps = listParams.open_steps;
+      const desiredOpenSet =
+        urlOpenSteps === ''
+          ? new Set<string>()
+          : !urlOpenSteps || urlOpenSteps === 'all'
+            ? new Set(visibleStepNames)
+            : new Set(
+                urlOpenSteps
+                  .split(',')
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              );
+
+      const currentOpenSet = new Set(visibleStepNames.filter((name) => rows[name]?.isOpen));
+      const desiredSorted = [...desiredOpenSet].sort().join(',');
+      const currentSorted = [...currentOpenSet].sort().join(',');
+
+      if (desiredSorted !== currentSorted) {
+        dispatch({ type: 'closeAll' });
+        desiredOpenSet.forEach((stepName) => {
+          if (rows[stepName]) dispatch({ type: 'open', id: stepName });
+        });
+        lastOpenStepsFromUrlRef.current = desiredOpenSet.size === visibleStepNames.length ? 'all' : desiredSorted;
+      } else {
+        const allOpen = visibleStepNames.length === currentOpenSet.size;
+        lastOpenStepsFromUrlRef.current = allOpen ? 'all' : currentSorted;
+      }
+      lastKnownStepNamesRef.current = visibleSet;
+    };
+
+    if (!isInitializedRef.current) {
+      applyUrlToState();
+      isInitializedRef.current = true;
+      return;
+    }
+
+    // New steps load expanded by default, so apply URL state if we have open_steps.
+    if (hasNewSteps && listParams.open_steps) {
+      applyUrlToState();
+      return;
+    }
+
+    // User toggle
+    lastKnownStepNamesRef.current = visibleSet;
+    const openSteps = visibleStepNames.filter((name) => rows[name]?.isOpen);
+    const allOpen = openSteps.length === visibleStepNames.length;
+    const currentRepr = allOpen ? 'all' : openSteps.sort().join(',');
+
+    if (currentRepr === lastOpenStepsFromUrlRef.current) return;
+
+    lastOpenStepsFromUrlRef.current = currentRepr;
+    setQueryParam({ open_steps: allOpen ? undefined : currentRepr }, 'replaceIn');
+  }, [rows, listParams.open_steps, dispatch, setQueryParam]);
+
   useEffect(() => {
     setPreviousStepName(params.stepName || undefined);
     setPreviousTaskId(params.taskId || undefined);
@@ -147,10 +222,6 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
   //
   // Graph measurements and rendering logic
   //
-
-  useEffect(() => {
-    dispatch({ type: 'reset' });
-  }, [params.runNumber, dispatch]);
 
   //
   // Data processing


### PR DESCRIPTION
The timeline view's expand/collapse state was not reflected in the URL, making it impossible to share a view showing a specific set of tasks. Recipients would always see the default expanded state instead of what the sharer was viewing.

This PR adds an `open_steps` query parameter that persists the expand/collapse state of timeline steps in the URL.

### Closes #42 

### Behavior
<html>
<body>


URL state | Meaning
-- | --
No open_steps param | All steps expanded (default) — clean URLs
?open_steps=start,end | Only these steps are expanded
?open_steps= (empty) | All steps collapsed


<!-- notionvc: 59792d01-ab03-428a-b61f-a80b5d625bf6 --><!--EndFragment-->
</body>
</html>


### Changes
- **`useTaskListSettings.ts`** — Added `open_steps` as a URL query param via `use-query-params`. Excluded from custom mode localStorage presets.
- **`RunPage.tsx`** — Single `useEffect` with phase tracking: applies URL state on initial load, syncs state URL on user toggle. Uses `replaceIn` so expand/collapse actions don't create browser history entries.
- **`cypress/integration/run_details.js`** — Extended existing collapse tests with 3 new assertions for `open_steps` URL behavior.
- `PluginRegisterSystem.tsx` (additional fix) — Fixed a pre-existing crash when the `/plugin` API returns a response instead of a plain array. This was blocking local development and was fixed while working on this PR.

### Screenshots
**Steps collapsed - `open_steps` param in URL**
<img width="2856" height="1359" alt="Untitled-2026-01-23-2132 excalidraw" src="https://github.com/user-attachments/assets/402a233f-5396-4d49-9679-4016a7d2de83" />

**Steps expanded - `param` removed from URL**
<img width="3090" height="1400" alt="expanded" src="https://github.com/user-attachments/assets/057924f9-3b3f-4c73-bd38-2e2378e00895" />


### Video Demo

https://github.com/user-attachments/assets/a1e743bc-325b-4e32-a7ea-af67cb59defc

### Edge Cases Handled
- Steps that load late are closed if they're not in the URL's open list
- Switching to a different run reset everything cleanly
- All open = no param in URL, all closed = `open_steps=` (empty), these are treated differently