### PR TITLE
feat: persist timeline expand/collapse state in URL

### DIFF
--- a/src/pages/Run/RunPage.tsx
+++ b/src/pages/Run/RunPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Run as IRun, Metadata } from '@/types';
@@ -93,17 +93,22 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
       });
     }
   }, [dispatch]);
-  // Sync open steps to URL whenever rows change
+  // Derive open step keys as a stable string so URL updates only fire when steps are toggled
+  const openStepKeys = useMemo(
+    () => Object.keys(rows).filter((key) => rows[key].isOpen).join(','),
+    [rows],
+  );
+
+  // Sync open steps to URL whenever open steps actually change
   useEffect(() => {
-    const openSteps = Object.keys(rows).filter((key) => rows[key].isOpen);
     const urlSearchParams = new URLSearchParams(window.location.search);
-    if (openSteps.length > 0) {
-      urlSearchParams.set('timeline', openSteps.join(','));
+    if (openStepKeys) {
+      urlSearchParams.set('timeline', openStepKeys);
     } else {
       urlSearchParams.delete('timeline');
     }
     window.history.replaceState(null, '', '?' + urlSearchParams.toString());
-  }, [rows]);
+  }, [openStepKeys]);
   const onUpdate = useCallback(
     (items: Metadata[]) => {
       const record = metadataToRecord(items);

--- a/src/pages/Run/RunPage.tsx
+++ b/src/pages/Run/RunPage.tsx
@@ -82,7 +82,28 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
   //
   // Metadata for plugins
   //
-
+  // Restore timeline open steps from URL on mount
+  useEffect(() => {
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const timelineParam = urlSearchParams.get('timeline');
+    if (timelineParam) {
+      const openSteps = timelineParam.split(',');
+      openSteps.forEach((stepId) => {
+        dispatch({ type: 'open', id: stepId });
+      });
+    }
+  }, [dispatch]);
+  // Sync open steps to URL whenever rows change
+  useEffect(() => {
+    const openSteps = Object.keys(rows).filter((key) => rows[key].isOpen);
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    if (openSteps.length > 0) {
+      urlSearchParams.set('timeline', openSteps.join(','));
+    } else {
+      urlSearchParams.delete('timeline');
+    }
+    window.history.replaceState(null, '', '?' + urlSearchParams.toString());
+  }, [rows]);
   const onUpdate = useCallback(
     (items: Metadata[]) => {
       const record = metadataToRecord(items);


### PR DESCRIPTION


### Description of the Change

Encodes the explicitly opened steps in the URL as a query param — 
e.g. ?timeline=start,train — so shared links restore the same 
timeline view for the recipient. Addresses #42.

### Alternate Designs

Considered encoding full expand/collapse state for every step, 
but encoding only opened steps keeps URLs shorter. Collapsed 
state is the default so it doesn't need to be represented.

Considered using history.pushState but replaceState was chosen 
so back button behavior stays normal — each expand/collapse 
overwrites the current URL entry rather than stacking history.

### Possible Drawbacks

If a run has steps with commas in the name, the param encoding 
could break. Current Metaflow step names don't allow commas so 
this is not a concern in practice.

### Verification Process

Verified the app compiles with no errors and no lint warnings (npm run lint is clean) 
after the change. logic follows existing URL param 
patterns already used in the codebase.

### Release Notes

Timeline expand/collapse state is now persisted in the URL, 
allowing users to share links that restore the same view.
