### PR TITLE
fix: handle corrupt localStorage values without crashing

### DIFF
--- a/src/components/Timeline/useTaskListSettings.ts
+++ b/src/components/Timeline/useTaskListSettings.ts
@@ -236,10 +236,14 @@ export default function useTaskListSettings(): TaskSettingsHook {
         // Check previous settings from localstorage for custom setting
         const previousSettings = localStorage.getItem('custom-settings');
         if (previousSettings) {
-          const parsed = JSON.parse(previousSettings);
-          if (parsed) {
-            const steps = q.steps ? { steps: q.steps } : {};
-            sq({ ...parsed, ...steps }, 'replace');
+          try {
+            const parsed = JSON.parse(previousSettings);
+            if (parsed) {
+              const steps = q.steps ? { steps: q.steps } : {};
+              sq({ ...parsed, ...steps }, 'replace');
+            }
+          } catch {
+            localStorage.removeItem('custom-settings');
           }
         }
       }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -55,7 +55,12 @@ const Home: React.FC = () => {
       // Try to use same params as last time when on frontpage. But only try this if
       // user is coming to default frontpage. We don't want to interrupt direct links from working
       const fromLS = localStorage.getItem('home-params');
-      const lastUsedParams = fromLS ? JSON.parse(fromLS) : false;
+      let lastUsedParams = false;
+      try {
+        lastUsedParams = fromLS ? JSON.parse(fromLS) : false;
+      } catch {
+        localStorage.removeItem('home-params');
+      }
       if (lastUsedParams && isDefaultParams(rawParams, false)) {
         setQp(lastUsedParams);
       }
@@ -83,7 +88,9 @@ const Home: React.FC = () => {
       params: rawParams,
       cachedResult: shouldUseCachedResult(historyAction),
     });
-    localStorage.setItem('home-params', JSON.stringify(rawParams));
+    try {
+      localStorage.setItem('home-params', JSON.stringify(rawParams));
+    } catch {}
   }, [historyAction, rawParams]);
 
   //


### PR DESCRIPTION
JSON.parse was called without try/catch on values read from localStorage in two places.

If the stored value is invalid JSON (due to a browser crash, manual edit, or storage corruption), the app throws an unhandled SyntaxError and crashes to a white screen.

- Home page (home-params): wrap JSON.parse in try/catch, clear the corrupt key so the page loads with default params instead of crashing
- useTaskListSettings (custom-settings): same fix for the run timeline
- Home page (localStorage.setItem): wrap in try/catch to handle QuotaExceededError gracefully