### PR TITLE
feat: distinguish externally killed tasks from code failures (#84)

### DIFF
--- a/src/components/DAG/components/DAGContent.tsx
+++ b/src/components/DAG/components/DAGContent.tsx
@@ -259,7 +259,9 @@ const StatusColorStyles = css<{ state: TaskStatus }>`
           ? 'var(--color-text-warning)'
           : p.state === 'failed'
             ? 'var(--color-text-danger)'
-            : 'var(--color-border-2)'};
+            : p.state === 'killed'
+              ? 'var(--color-text-warning)'
+              : 'var(--color-border-2)'};
   background: ${(p) =>
     p.state === 'completed'
       ? 'color-mix(in hsl, var(--color-text-success) 5%, #fff)'
@@ -267,7 +269,9 @@ const StatusColorStyles = css<{ state: TaskStatus }>`
         ? 'color-mix(in hsl, var(--color-text-warning) 5%, #fff)'
         : p.state === 'failed'
           ? 'color-mix(in hsl, var(--color-text-danger) 5%, #fff)'
-          : '#fff'};
+          : p.state === 'killed'
+            ? 'color-mix(in hsl, var(--color-text-warning) 5%, #fff)'
+            : '#fff'};
 `;
 
 const NormalItem = styled.div<{ state: TaskStatus }>`

--- a/src/components/TaskListingHeader/components/CustomSettings.tsx
+++ b/src/components/TaskListingHeader/components/CustomSettings.tsx
@@ -81,8 +81,8 @@ const CustomSettings: React.FC<CustomSettingsProps> = ({
               ['running', t('run.filter-running') + ` (${counts.running})`],
               ['pending', t('run.filter-pending') + ` (${counts.pending})`],
               ['failed', t('run.filter-failed') + ` (${counts.failed})`],
-              ...(counts.unknown > 0
-                ? ([['unknown', t('run.filter-unknown') + ` (${counts.unknown})`]] as [string, string][])
+              ...(counts.killed > 0
+                ? ([['killed', t('run.filter-killed') + ` (${counts.killed})`]] as [string, string][])
                 : []),
             ]}
             labelRenderer={(value, label) => <StatusLabelRenderer val={label} status={value} />}

--- a/src/components/TaskListingHeader/components/CustomSettings.tsx
+++ b/src/components/TaskListingHeader/components/CustomSettings.tsx
@@ -84,6 +84,9 @@ const CustomSettings: React.FC<CustomSettingsProps> = ({
               ...(counts.killed > 0
                 ? ([['killed', t('run.filter-killed') + ` (${counts.killed})`]] as [string, string][])
                 : []),
+              ...(counts.unknown > 0
+                ? ([['unknown', t('run.filter-unknown') + ` (${counts.unknown})`]] as [string, string][])
+                : []),
             ]}
             labelRenderer={(value, label) => <StatusLabelRenderer val={label} status={value} />}
             optionRenderer={(value, label) => <StatusLabelRenderer val={label} status={value} />}

--- a/src/components/TaskListingHeader/components/StatusLights.tsx
+++ b/src/components/TaskListingHeader/components/StatusLights.tsx
@@ -24,6 +24,7 @@ const StatusLights: React.FC<Props> = ({ status }) => (
     )}
     {status === 'completed' && <StatusBox status="completed" />}
     {status === 'failed' && <StatusBox status="failed" />}
+    {status === 'killed' && <StatusBox status="killed" />}
     {status === 'running' && <StatusBox status="running" />}
     {status === 'pending' && <StatusBox status="pending" />}
     {status === 'unknown' && <StatusBox status="unknown" />}

--- a/src/components/TaskListingHeader/components/StatusLights.tsx
+++ b/src/components/TaskListingHeader/components/StatusLights.tsx
@@ -20,6 +20,7 @@ const StatusLights: React.FC<Props> = ({ status }) => (
         <StatusBox status="running" />
         <StatusBox status="pending" />
         <StatusBox status="failed" />
+        <StatusBox status="killed" />
       </>
     )}
     {status === 'completed' && <StatusBox status="completed" />}

--- a/src/components/Timeline/taskdataUtils.ts
+++ b/src/components/Timeline/taskdataUtils.ts
@@ -11,6 +11,7 @@ export type RowCounts = {
   running: number;
   pending: number;
   failed: number;
+  killed: number;
   unknown: number;
 };
 
@@ -20,6 +21,7 @@ export function countTaskRowsByStatus(rows: RowDataModel): RowCounts {
     completed: 0,
     running: 0,
     failed: 0,
+    killed: 0,
     pending: 0,
     unknown: 0,
   };
@@ -122,8 +124,11 @@ export function getStepStatus(stepTaskData: Record<string, Task[]>): TaskStatus 
       return 'running';
     }
     if (statusOfLastItem === 'failed') {
-      return 'failed';
-    }
+        return 'failed';
+        }
+    if (statusOfLastItem === 'killed') {
+        return 'killed';
+              }
   }
   return 'completed';
 }

--- a/src/components/Timeline/taskdataUtils.ts
+++ b/src/components/Timeline/taskdataUtils.ts
@@ -124,11 +124,11 @@ export function getStepStatus(stepTaskData: Record<string, Task[]>): TaskStatus 
       return 'running';
     }
     if (statusOfLastItem === 'failed') {
-        return 'failed';
-        }
+      return 'failed';
+    }
     if (statusOfLastItem === 'killed') {
-        return 'killed';
-              }
+      return 'killed';
+    }
   }
   return 'completed';
 }

--- a/src/components/Timeline/useTaskData.ts
+++ b/src/components/Timeline/useTaskData.ts
@@ -302,6 +302,7 @@ export default function useTaskData(flowId: string, runNumber: string): useTaskD
     completed: 0,
     running: 0,
     failed: 0,
+    killed: 0,
     pending: 0,
     unknown: 0,
   });

--- a/src/pages/Home/ResultGroup/TimelinePreview.tsx
+++ b/src/pages/Home/ResultGroup/TimelinePreview.tsx
@@ -9,7 +9,7 @@ import { Row } from '@components/Timeline/VirtualizedTimeline';
 import useTaskData from '@components/Timeline/useTaskData';
 import { startAndEndpointsOfRows } from '@utils/row';
 
-const zeroCounts = { all: 0, failed: 0, running: 0, completed: 0, unknown: 0, pending: 0 };
+const zeroCounts = { all: 0, failed: 0, running: 0, completed: 0, unknown: 0, pending: 0, killed: 0 };
 
 //
 // Typedef

--- a/src/pages/Run/RunPage.tsx
+++ b/src/pages/Run/RunPage.tsx
@@ -82,7 +82,28 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
   //
   // Metadata for plugins
   //
-
+  // Restore timeline open steps from URL on mount
+  useEffect(() => {
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const timelineParam = urlSearchParams.get('timeline');
+    if (timelineParam) {
+      const openSteps = timelineParam.split(',');
+      openSteps.forEach((stepId) => {
+        dispatch({ type: 'open', id: stepId });
+      });
+    }
+  }, [dispatch]);
+  // Sync open steps to URL whenever rows change
+  useEffect(() => {
+    const openSteps = Object.keys(rows).filter((key) => rows[key].isOpen);
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    if (openSteps.length > 0) {
+      urlSearchParams.set('timeline', openSteps.join(','));
+    } else {
+      urlSearchParams.delete('timeline');
+    }
+    window.history.replaceState(null, '', '?' + urlSearchParams.toString());
+  }, [rows]);
   const onUpdate = useCallback(
     (items: Metadata[]) => {
       const record = metadataToRecord(items);

--- a/src/pages/Run/RunPage.tsx
+++ b/src/pages/Run/RunPage.tsx
@@ -82,28 +82,7 @@ const RunPage: React.FC<RunPageProps> = ({ run, params }) => {
   //
   // Metadata for plugins
   //
-  // Restore timeline open steps from URL on mount
-  useEffect(() => {
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    const timelineParam = urlSearchParams.get('timeline');
-    if (timelineParam) {
-      const openSteps = timelineParam.split(',');
-      openSteps.forEach((stepId) => {
-        dispatch({ type: 'open', id: stepId });
-      });
-    }
-  }, [dispatch]);
-  // Sync open steps to URL whenever rows change
-  useEffect(() => {
-    const openSteps = Object.keys(rows).filter((key) => rows[key].isOpen);
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    if (openSteps.length > 0) {
-      urlSearchParams.set('timeline', openSteps.join(','));
-    } else {
-      urlSearchParams.delete('timeline');
-    }
-    window.history.replaceState(null, '', '?' + urlSearchParams.toString());
-  }, [rows]);
+
   const onUpdate = useCallback(
     (items: Metadata[]) => {
       const record = metadataToRecord(items);

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -108,6 +108,7 @@ const en = {
       'filter-completed': 'Completed',
       'filter-running': 'Running',
       'filter-failed': 'Failed',
+      'filter-killed': 'Killed',
       'filter-pending': 'Pending',
       'filter-unknown': 'Unknown',
       mode: 'Mode',

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface Task extends MetaDataBaseObject {
   duration?: number;
   status: TaskStatus;
 }
+
 export type TaskStatus = 'running' | 'completed' | 'failed' | 'killed' | 'unknown' | 'pending' | 'refining';
 
 export interface Metadata extends MetaDataBaseObject {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,8 +47,7 @@ export interface Task extends MetaDataBaseObject {
   duration?: number;
   status: TaskStatus;
 }
-
-export type TaskStatus = 'running' | 'completed' | 'failed' | 'unknown' | 'pending' | 'refining';
+export type TaskStatus = 'running' | 'completed' | 'failed' | 'killed' | 'unknown' | 'pending' | 'refining';
 
 export interface Metadata extends MetaDataBaseObject {
   id: number;

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -37,6 +37,8 @@ export function colorByStatus(status: string): string {
       return 'var(--color-bg-success)';
     case 'failed':
       return 'var(--color-bg-danger)';
+    case 'killed':
+      return 'var(--color-bg-warning)';
     case 'running':
       return 'var(--color-bg-success-light)';
     case 'pending':
@@ -54,6 +56,8 @@ export function iconByStatus(status: keyof RunStatus | TaskStatus): keyof Suppor
     case 'completed':
       return 'completed';
     case 'failed':
+      return 'error';
+    case 'killed':
       return 'error';
     case 'running':
       return 'running';

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -58,7 +58,7 @@ export function iconByStatus(status: keyof RunStatus | TaskStatus): keyof Suppor
     case 'failed':
       return 'error';
     case 'killed':
-      return 'error';
+      return 'warning';
     case 'running':
       return 'running';
     default:


### PR DESCRIPTION
## Description of the Change  
Closes #84  

All terminal task failures currently render as identical red "Failed" states, conflating two fundamentally different failure modes:

- **Code failures**: Python exception, the user's code is the cause  
- **Killed tasks**: SIGKILL from OOM killer, Kubernetes eviction, external process termination, infrastructure is the cause  

This PR adds a distinct killed status with amber color and warning icon so users can immediately distinguish whether to debug their code or their infrastructure.  

The distinguishing signal lives in the backend SQL (companion PR to Netflix/metaflow-service https://github.com/Netflix/metaflow-service/pull/468 ). When a task fails via Python exception, Metaflow writes `attempt_ok = "False"` in the finally block of task.py. When killed with SIGKILL, the finally block never runs, so no `attempt_ok` metadata is written. The backend now derives `killed` from this absence and exposes it in the task status field.  

---

## Files changed

- `src/types.ts`: added `killed` to TaskStatus union  
- `src/utils/style.ts`: amber color and warning icon for killed status  
- `src/components/Timeline/taskdataUtils.ts`: killed in RowCounts and getStepStatus  
- `src/components/Timeline/useTaskData.ts`: killed: 0 in initial counts  
- `src/pages/Home/ResultGroup/TimelinePreview.tsx`: killed in zeroCounts  
- `src/components/TaskListingHeader/components/StatusLights.tsx`: killed status light  
- `src/components/TaskListingHeader/components/CustomSettings.tsx`: killed filter option  
- `src/translations/en.ts`: filter-killed translation  

**Note:** Run-level status on the home screen continues to show **"Failed"** for both failure modes. This is correct since the run itself failed in both cases. The killed or failed distinction is exposed at the task level in the timeline view and filter, which is where users investigate failure causes.  

---

## Alternate Designs

Considered deriving killed status on the frontend by checking `attempt_ok` metadata absence in `useTaskMetadata`. Rejected because metadata loads asynchronously after the task, causing a flicker and creating two sources of truth. Backend derivation via SQL is consistent with how the existing codebase handles all other status derivation, and matches Sakari's stated preference for backend as single source of truth.  

---

## Possible Drawbacks

The killed status appears after the heartbeat threshold passes (about 60 seconds by default). During this window the task shows as running. This is existing behavior for all failed tasks and is not introduced by this change.  

---

## Verification Process

Ran two flows locally against a full metaflow-service Docker stack:

### **FailFlow**
- raises `ValueError("deliberate failure")`  
- curl result: `"status": "failed"`  
- UI: red dot, Failed (1) in filter, not counted as killed  

### **KillFlow**
- calls `os.kill(os.getpid(), signal.SIGKILL)`  
- curl result after 90s: `"status": "killed"`  
- UI: amber dot, Killed (1) in filter, Failed (0), correctly not counted as failed  

---

## Screenshots

**FailFlow (terminal)**  
![FailFlow](https://github.com/user-attachments/assets/a52f3eb6-ffde-4acd-89f1-2468956eba57)

**KillFlow (terminal)**  
![API](https://github.com/user-attachments/assets/98c10bba-6405-4778-bb50-94faf3464742)

**FailFlow UI timeline**  
![KillFlow](https://github.com/user-attachments/assets/9bcf57b0-ead9-44a4-a618-be72373793c7)

**KillFlow UI timeline and dropbox**  
![Extra](https://github.com/user-attachments/assets/9ffd1f6e-e541-4d17-b4ab-b8444ab0a2ed)

---

## Release Notes

Externally killed tasks (SIGKILL, OOM killer, Kubernetes eviction) now display with a distinct amber warning indicator instead of the red failed indicator, allowing users to immediately distinguish infrastructure failures from code failures.  