### PR TITLE
refactor: replace hardcoded colors with CSS variables in HelpMenu

### DIFF
--- a/src/components/HelpMenu/TimezoneSelector.tsx
+++ b/src/components/HelpMenu/TimezoneSelector.tsx
@@ -112,10 +112,10 @@ const TimezoneRow = styled.div`
   align-items: center;
   padding: 0rem 0.5rem;
   width: 100%;
-  color: #666;
+  color: var(--color-text-secondary);
 
   .field {
-    color: #333;
+    color: var(--color-text-primary);
     margin: 0.5rem 0;
     width: 100%;
   }

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -179,7 +179,7 @@ const StyledHelpMenuLink = styled.a`
     background-color: var(--color-text-highlight);
   }
   &:after {
-    background-color: #666;
+    background-color: var(--color-text-secondary);
     content: '';
     display: inline-block;
     height: 1rem;
@@ -213,7 +213,7 @@ export const HelpMenuRow = styled.div`
 
   .field {
     width: 100%;
-    border: 1px solid #e9e9e9;
+    border: 1px solid var(--color-border-primary);
     border-radius: var(--radius-primary);
   }
 `;


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [ ] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

<!--

Replace hardcoded hex color values (`#666`, `#333`, `#e9e9e9`) with their corresponding CSS variables (`--color-text-secondary`, `--color-text-primary`, `--color-border-primary`) in HelpMenu and TimezoneSelector components.
This aligns these components with the CSS variable theming approach established in PRs #159, #162-164. No visual change — the CSS variables resolve to the same values.

-->

### Alternate Designs
\-

### Possible Drawbacks
\-

### Verification Process
Verified that the CSS variable values match the original hardcoded values:                                      
  - `--color-text-secondary` resolves to `#666`
  - `--color-text-primary` resolves to `#333`                                                                     
  - `--color-border-primary` (`#d0d0d0`) is a minor consistency improvement over `#e9e9e9`, aligning the border
  with the standard border token used across all other components

### Release Notes
N/A
