### PR TITLE
feat: theming, UI polish and dark mode integrations (#157)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import PluginRegisterSystem from '@components/Plugins/PluginRegisterSystem';
 import TopNavPlugin from '@components/Plugins/TopNavPlugin';
 import { Page } from '@components/Structure';
 import { TimezoneProvider } from '@components/TimezoneProvider';
+import { ThemeProvider } from '@components/ThemeProvider';
 import { LoggingProvider } from '@hooks/useLogger';
 import { fetchFeaturesConfig } from '@utils/FEATURE';
 import { fetchServiceVersion } from '@utils/VERSION';
@@ -35,6 +36,7 @@ const App: React.FC = () => {
   }, []);
 
   return (
+    <ThemeProvider>
     <ErrorBoundary message={t('error.application-error')}>
       <NotificationsProvider>
         <TimezoneProvider>
@@ -65,6 +67,7 @@ const App: React.FC = () => {
         </TimezoneProvider>
       </NotificationsProvider>
     </ErrorBoundary>
+    </ThemeProvider>
   );
 };
 

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -8,6 +8,8 @@ const globalCSS = css`
 
   html {
     font-size: var(--html-document-font-size);
+    /* Lets browser-native elements (scrollbars, inputs, selects) adapt to dark mode too */
+    color-scheme: light dark;
   }
 
   body,
@@ -25,6 +27,7 @@ const globalCSS = css`
     -moz-osx-font-smoothing: grayscale;
     color: var(--color-text-primary);
     background: var(--layout-color-bg);
+    color-scheme: light dark;
   }
 
   a {

--- a/src/assets/moon.svg
+++ b/src/assets/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+</svg>

--- a/src/assets/sun.svg
+++ b/src/assets/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="5"/>
+  <line x1="12" y1="1" x2="12" y2="3"/>
+  <line x1="12" y1="21" x2="12" y2="23"/>
+  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+  <line x1="1" y1="12" x2="3" y2="12"/>
+  <line x1="21" y1="12" x2="23" y2="12"/>
+  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+</svg>

--- a/src/components/AppBar/index.tsx
+++ b/src/components/AppBar/index.tsx
@@ -8,6 +8,7 @@ import PluginGroup from '@components/Plugins/PluginGroup';
 import { ItemRow } from '@components/Structure';
 import FEATURE_FLAGS from '@utils/FEATURE';
 import logo from '@assets/logo_dark_horizontal.svg';
+import DarkModeToggle from '@components/DarkModeToggle';
 
 //
 // Main application bar which is always shown on top of the page
@@ -24,6 +25,7 @@ const AppBar: React.FC = () => {
         )}
         <Breadcrumb />
         {!FEATURE_FLAGS.HIDE_QUICK_LINKS && <HelpMenu />}
+        <DarkModeToggle />
         {!FEATURE_FLAGS.HIDE_CONNECTION_STATUS && <ConnectionStatus />}
       </ItemRow>
       <ItemRow pad="lg">

--- a/src/components/DAG/components/DAGContent.tsx
+++ b/src/components/DAG/components/DAGContent.tsx
@@ -228,7 +228,7 @@ const Line = css`
     top: 0;
     width: 1px;
     height: 100%;
-    background: #d0d0d0;
+    background: var(--color-border-2);
     left: 50%;
   }
 `;
@@ -262,12 +262,12 @@ const StatusColorStyles = css<{ state: TaskStatus }>`
             : 'var(--color-border-2)'};
   background: ${(p) =>
     p.state === 'completed'
-      ? 'color-mix(in hsl, var(--color-text-success) 5%, #fff)'
+      ? 'color-mix(in hsl, var(--color-text-success) 8%, var(--dag-node-bg, var(--color-bg-primary)))'
       : p.state === 'running'
-        ? 'color-mix(in hsl, var(--color-text-warning) 5%, #fff)'
+        ? 'color-mix(in hsl, var(--color-text-warning) 8%, var(--dag-node-bg, var(--color-bg-primary)))'
         : p.state === 'failed'
-          ? 'color-mix(in hsl, var(--color-text-danger) 5%, #fff)'
-          : '#fff'};
+          ? 'color-mix(in hsl, var(--color-text-danger) 8%, var(--dag-node-bg, var(--color-bg-primary)))'
+          : 'var(--dag-node-bg, var(--color-bg-primary))'};
 `;
 
 const NormalItem = styled.div<{ state: TaskStatus }>`
@@ -282,7 +282,7 @@ const NormalItem = styled.div<{ state: TaskStatus }>`
 
 const BaseContainerStyle = css`
   border: var(--border-thin-2);
-  background: #f6f6f6;
+  background: var(--dag-container-bg, var(--color-bg-secondary));
   display: flex;
   border-radius: var(--radius-secondary);
   position: relative;
@@ -295,14 +295,14 @@ const ContainerItem = styled.div`
 
 const ForeachContainer = styled.div`
   ${BaseContainerStyle}
-  background: rgba(192, 192, 192, 0.3);
+  background: var(--dag-foreach-bg, rgba(128, 128, 128, 0.2));
   transform: translateX(-0.275rem) translateY(-0.275rem);
   margin-top: 0.1875rem;
 `;
 
 const ForeachItem = styled.div`
   ${BaseContainerStyle}
-  background: #f6f6f6;
+  background: var(--dag-node-bg, var(--color-bg-primary));
   margin: 0;
   transform: translateX(0.275rem) translateY(0.275rem);
   flex: 1;
@@ -314,11 +314,11 @@ const StepInfoMarker = styled.div`
   right: 0.4rem;
 
   path {
-    fill: #717171;
+    fill: var(--color-text-secondary);
   }
 
   &:hover path {
-    fill: #333;
+    fill: var(--color-text-primary);
   }
 `;
 

--- a/src/components/DarkModeToggle/__tests__/DarkModeToggle.test.cypress.tsx
+++ b/src/components/DarkModeToggle/__tests__/DarkModeToggle.test.cypress.tsx
@@ -5,7 +5,6 @@ import DarkModeToggle from '..';
 
 describe('DarkModeToggle component test', () => {
   it('should toggle theme on click', () => {
-    // Standard viewport for component testing
     cy.viewport(400, 400);
 
     mount(
@@ -14,24 +13,18 @@ describe('DarkModeToggle component test', () => {
       </TestWrapper>,
     );
 
-    // 1. Check initial state (should default to light mode aria-label in test env)
-    // Note: getInitialTheme in ThemeProvider checks matchMedia and localStorage.
-    // In Cypress test environment, it likely defaults to 'light'.
     cy.get('[data-testid="dark-mode-toggle"]')
       .should('have.attr', 'aria-label')
       .then((ariaLabel: any) => {
         const ariaLabelStr = String(ariaLabel);
         const isInitialDark = ariaLabelStr === 'Switch to light mode';
         
-        // 2. Click the toggle
         cy.get('[data-testid="dark-mode-toggle"]').click();
 
-        // 3. Verify it changed to the opposite
         const expectedLabel = isInitialDark ? 'Switch to dark mode' : 'Switch to light mode';
         cy.get('[data-testid="dark-mode-toggle"]')
           .should('have.attr', 'aria-label', expectedLabel);
 
-        // 4. Click again and verify it returns to initial
         cy.get('[data-testid="dark-mode-toggle"]').click();
         cy.get('[data-testid="dark-mode-toggle"]')
           .should('have.attr', 'aria-label', ariaLabel);

--- a/src/components/DarkModeToggle/__tests__/DarkModeToggle.test.cypress.tsx
+++ b/src/components/DarkModeToggle/__tests__/DarkModeToggle.test.cypress.tsx
@@ -1,0 +1,40 @@
+import { mount } from '@cypress/react';
+import React from 'react';
+import TestWrapper from '@utils/testing';
+import DarkModeToggle from '..';
+
+describe('DarkModeToggle component test', () => {
+  it('should toggle theme on click', () => {
+    // Standard viewport for component testing
+    cy.viewport(400, 400);
+
+    mount(
+      <TestWrapper>
+        <DarkModeToggle />
+      </TestWrapper>,
+    );
+
+    // 1. Check initial state (should default to light mode aria-label in test env)
+    // Note: getInitialTheme in ThemeProvider checks matchMedia and localStorage.
+    // In Cypress test environment, it likely defaults to 'light'.
+    cy.get('[data-testid="dark-mode-toggle"]')
+      .should('have.attr', 'aria-label')
+      .then((ariaLabel: any) => {
+        const ariaLabelStr = String(ariaLabel);
+        const isInitialDark = ariaLabelStr === 'Switch to light mode';
+        
+        // 2. Click the toggle
+        cy.get('[data-testid="dark-mode-toggle"]').click();
+
+        // 3. Verify it changed to the opposite
+        const expectedLabel = isInitialDark ? 'Switch to dark mode' : 'Switch to light mode';
+        cy.get('[data-testid="dark-mode-toggle"]')
+          .should('have.attr', 'aria-label', expectedLabel);
+
+        // 4. Click again and verify it returns to initial
+        cy.get('[data-testid="dark-mode-toggle"]').click();
+        cy.get('[data-testid="dark-mode-toggle"]')
+          .should('have.attr', 'aria-label', ariaLabel);
+      });
+  });
+});

--- a/src/components/DarkModeToggle/index.tsx
+++ b/src/components/DarkModeToggle/index.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useTheme } from '@components/ThemeProvider';
+import moonIcon from '@assets/moon.svg';
+import sunIcon from '@assets/sun.svg';
+
+//
+// A compact sun/moon icon button that toggles between light and dark mode.
+// Placed in the AppBar next to "Quick links".
+//
+
+const DarkModeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <ToggleButton
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      data-testid="dark-mode-toggle"
+    >
+      <IconMask iconUrl={isDark ? sunIcon : moonIcon} />
+    </ToggleButton>
+  );
+};
+
+export default DarkModeToggle;
+
+//
+// Style
+//
+
+const ToggleButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.375rem;
+  height: 2.375rem;
+  border-radius: var(--radius-primary);
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  color: var(--color-text-secondary);
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--color-bg-secondary);
+    color: var(--color-text-primary);
+    border-color: rgba(128, 128, 128, 0.5);
+  }
+`;
+
+// Renders the SVG as a CSS mask so it inherits `currentColor` from the button
+const IconMask = styled.span<{ iconUrl: string }>`
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  background-color: currentColor;
+  -webkit-mask: url(${(p) => p.iconUrl}) no-repeat center;
+  mask: url(${(p) => p.iconUrl}) no-repeat center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+`;

--- a/src/components/DarkModeToggle/index.tsx
+++ b/src/components/DarkModeToggle/index.tsx
@@ -4,11 +4,6 @@ import { useTheme } from '@components/ThemeProvider';
 import moonIcon from '@assets/moon.svg';
 import sunIcon from '@assets/sun.svg';
 
-//
-// A compact sun/moon icon button that toggles between light and dark mode.
-// Placed in the AppBar next to "Quick links".
-//
-
 const DarkModeToggle: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
   const isDark = theme === 'dark';
@@ -53,7 +48,6 @@ const ToggleButton = styled.button`
   }
 `;
 
-// Renders the SVG as a CSS mask so it inherits `currentColor` from the button
 const IconMask = styled.span<{ iconUrl: string }>`
   display: block;
   width: 1rem;

--- a/src/components/Form/InputWrapper.tsx
+++ b/src/components/Form/InputWrapper.tsx
@@ -28,13 +28,15 @@ const InputWrapper = styled.section<InputWrapperProps>`
     padding-right: 1.5rem;
     font-size: var(--input-font-size);
 
+    color: var(--input-text-color);
+
     &:focus {
       outline: none;
       border: none;
     }
 
     &::placeholder {
-      color: var(--color-text-primary);
+      color: var(--input-placeholder-color);
       font-weight: 500;
       opacity: 1;
     }
@@ -51,9 +53,9 @@ const InputWrapper = styled.section<InputWrapperProps>`
     border-color: ${(p) =>
       p.status && p.status === 'Error'
         ? 'var(--color-bg-danger)'
-        : p.active
+         : p.active
           ? 'var(--color-text-highlight)'
-          : 'var(--color-text-primary)'};
+        : 'var(--color-text-primary)'};
   }
 `;
 

--- a/src/components/LogList/index.tsx
+++ b/src/components/LogList/index.tsx
@@ -299,6 +299,8 @@ const LogListContainer = styled.code`
   position: relative;
   overflow: hidden;
   white-space: pre-wrap;
+  background: var(--log-viewer-bg, #f5f5f5);
+  color: var(--log-viewer-color, var(--color-text-primary));
 `;
 
 const LogLine = styled.div`
@@ -333,9 +335,9 @@ const ScrollToBottomButton = styled.div`
   cursor: pointer;
   padding: 0.5rem;
   border-radius: var(--radius-primary);
-
-  background: rgba(0, 0, 0, 0.5);
-  color: var(--color-text-alternative);
+  background: var(--color-bg-heavy, rgba(0, 0, 0, 0.7));
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-2);
 `;
 
 export default LogList;

--- a/src/components/PropertyTable/index.tsx
+++ b/src/components/PropertyTable/index.tsx
@@ -111,7 +111,7 @@ const PropertyTableRowItemContent = styled.td<{ scheme: PropertyTableScheme }>`
   padding: 0.75rem 1rem;
   font-size: var(--font-size-primary);
   border-right: var(--border-alternative-medium);
-  background: ${(p) => (p.scheme === 'bright' ? 'var(--color-bg-primary)' : 'transparent')};
+  background: ${(p) => (p.scheme === 'bright' ? 'var(--property-table-bright-bg, var(--color-bg-primary))' : 'transparent')};
   word-break: break-word;
   &:last-child {
     border-right: none;

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 //
-// ThemeContext — provides light/dark mode state across the app.
 // Preference is persisted to localStorage and respects the OS default on first visit.
 //
 

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+//
+// ThemeContext — provides light/dark mode state across the app.
+// Preference is persisted to localStorage and respects the OS default on first visit.
+//
+
+type ThemeMode = 'light' | 'dark';
+
+type ThemeContextType = {
+  theme: ThemeMode;
+  toggleTheme: () => void;
+};
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => undefined,
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+const STORAGE_KEY = 'metaflow-ui-theme';
+
+function getInitialTheme(): ThemeMode {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch (_) {
+    // localStorage not available (SSR / privacy mode)
+  }
+  // Fall back to OS preference
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<ThemeMode>(getInitialTheme);
+
+  // Apply theme class to <html> so the CSS media-query override also works
+  // for components that have hardcoded checks. We also set the data-attribute
+  // so the CSS variable block can be activated by class as well.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.setAttribute('data-theme', 'dark');
+    } else {
+      root.setAttribute('data-theme', 'light');
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (_) {}
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+};

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -26,7 +26,6 @@ function getInitialTheme(): ThemeMode {
     const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
     if (stored === 'light' || stored === 'dark') return stored;
   } catch (_) {
-    // localStorage not available (SSR / privacy mode)
   }
   // Fall back to OS preference
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';

--- a/src/pages/Home/ResultGroup/ResultGroupHeader.tsx
+++ b/src/pages/Home/ResultGroup/ResultGroupHeader.tsx
@@ -20,7 +20,7 @@ const ResultGroupHeader: React.FC<ResultGroupHeaderProps> = React.memo(
     <>
       {!FEATURE_FLAGS.HIDE_TABLE_HEADER && (
         <TR className="result-group-title">
-          <th colSpan={cols.length + 1} style={{ textAlign: 'left' }}>
+          <th colSpan={cols.length + 1} style={{ textAlign: 'left', paddingLeft: '0.75rem' }}>
             <ResultGroupTitle onClick={() => (clickable ? handleClick(label) : null)} clickable={clickable}>
               {label}
             </ResultGroupTitle>

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -19,7 +19,7 @@
   --color-bg-secondary-highlight: #e4f0ff;
   --color-bg-heavy: #444;
 
-  /* --- Semantic surface tokens (themed per mode) --- */
+  /* --- Semantic surface (themed per mode) --- */
   --log-viewer-bg: #f5f5f5;
   --log-viewer-color: var(--color-text-primary);
   --property-table-bright-bg: var(--color-bg-primary);

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -19,7 +19,7 @@
   --color-bg-secondary-highlight: #e4f0ff;
   --color-bg-heavy: #444;
 
-  /* --- Semantic surface (themed per mode) --- */
+  /* --- Semantic surface --- */
   --log-viewer-bg: #f5f5f5;
   --log-viewer-color: var(--color-text-primary);
   --property-table-bright-bg: var(--color-bg-primary);
@@ -442,12 +442,10 @@
    ====================================================================== */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme]) {
-    /* --- Core brand colors stay the same, but we brighten slightly --- */
     --color-primary: #4a9eff;
     --color-secondary: #c8c8c8;
     --color-tertiary: #00d4e8;
 
-    /* --- Semantic status colors — brightened for dark backgrounds --- */
     --color-success: #4caf50;
     --color-success-light: rgba(76, 175, 80, 0.25);
     --color-warning: #ffb74d;
@@ -617,7 +615,7 @@
     --color-text-alternative: #e8e8e8;
     --input-text-color: var(--color-text-primary);
 
-    /* --- Table / property table borders (use subtle dark instead of thick white) --- */
+    /* --- Table / property table borders --- */
     --border-alternative-medium: 1px solid rgba(255, 255, 255, 0.1);
 
     /* --- Log viewer, property table bright cells --- */
@@ -630,8 +628,7 @@
 /* =====================================================================
    Dark Mode — Manual Toggle (data-theme="dark")
    Mirrors the media-query dark tokens so that the JS toggle works
-   independent of the OS setting.  When data-theme="light" is set it
-   also explicitly resets everything so switching back to light works.
+   independent of the OS setting.
    ====================================================================== */
 [data-theme='dark'] {
   /* Keep html color-scheme in sync so native elements (scrollbars, inputs) go dark */

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -19,6 +19,11 @@
   --color-bg-secondary-highlight: #e4f0ff;
   --color-bg-heavy: #444;
 
+  /* --- Semantic surface tokens (themed per mode) --- */
+  --log-viewer-bg: #f5f5f5;
+  --log-viewer-color: var(--color-text-primary);
+  --property-table-bright-bg: var(--color-bg-primary);
+
   --color-bg-brand-primary: var(--color-primary);
   --color-bg-brand-secondary: var(--color-secondary);
   --color-bg-brand-tertiary: var(--color-tertiary);
@@ -242,7 +247,7 @@
   --table-head-active-font-weight: var(--font-weight-medium);
 
   --table-cell-padding: var(--spacing-3) var(--spacing-7);
-  --table-cell-border: 1px solid #fff;
+  --table-cell-border: 1px solid #e0e0e0;
   --table-cell-border-top: var(--table-cell-border);
   --table-cell-border-right: var(--table-cell-border);
   --table-cell-border-bottom: var(--table-cell-border);
@@ -283,8 +288,8 @@
   --titled-row-text-color: var(--color-text-primary);
 
   --titled-row-table-title-cell-width: 200px;
-  --titled-row-table-border-bottom: 2px solid #fff;
-  --titled-row-table-separator-border: 2px solid #fff;
+  --titled-row-table-border-bottom: 1px solid #e0e0e0;
+  --titled-row-table-separator-border: 1px solid #e0e0e0;
   --titled-row-table-value-font-size: var(--titled-row-font-size);
   --titled-row-table-value-text-color: var(--titled-row-text-color);
   --titled-row-table-value-font-weight: var(--font-weight-regular);
@@ -427,4 +432,394 @@
   --task-content-border-right: none;
 
   --loglist-button-size: 2.5rem;
+}
+
+/* =====================================================================
+   Dark Mode
+   Automatically applied when the OS/browser prefers a dark color scheme.
+   Override only the color/surface tokens — spacing, typography, and
+   layout tokens don't change between themes.
+   ====================================================================== */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    /* --- Core brand colors stay the same, but we brighten slightly --- */
+    --color-primary: #4a9eff;
+    --color-secondary: #c8c8c8;
+    --color-tertiary: #00d4e8;
+
+    /* --- Semantic status colors — brightened for dark backgrounds --- */
+    --color-success: #4caf50;
+    --color-success-light: rgba(76, 175, 80, 0.25);
+    --color-warning: #ffb74d;
+    --color-danger: #f06060;
+
+    /* --- Surface / background --- */
+    --color-bg-primary: #121212;
+    --color-bg-secondary: rgba(255, 255, 255, 0.05);
+    --color-bg-secondary-highlight: #1a3a5c;
+    --color-bg-heavy: #2a2a2a;
+
+    --color-bg-brand-primary: var(--color-primary);
+    --color-bg-brand-secondary: var(--color-secondary);
+    --color-bg-brand-tertiary: var(--color-tertiary);
+
+    --color-bg-success: #2e6b45;
+    --color-bg-success-light: #4a7a10;
+    --color-bg-warning: #8a6120;
+    --color-bg-danger: #8a3c3c;
+    --color-bg-neutral: #2c2c2e;
+    --color-bg-disabled: #4a4a4a;
+
+    /* --- Borders --- */
+    --color-border-primary: #3a3a3a;
+    --color-border-1: rgba(255, 255, 255, 0.1);
+    --color-border-2: rgba(255, 255, 255, 0.2);
+    --color-border-3: rgba(255, 255, 255, 0.3);
+
+    /* --- Text --- */
+    --color-text-primary: #e8e8e8;
+    --color-text-secondary: #a0a0a0;
+    --color-text-light: #787878;
+    --color-text-alternative: #121212;
+    --color-text-highlight: #4a9eff;
+
+    --color-text-success: #66bb6a;
+    --color-text-info: #4dd0e1;
+    --color-text-warning: #ffb74d;
+    --color-text-danger: #f06060;
+
+    /* --- Icons --- */
+    --color-icon-light: #4a4a4a;
+    --color-icon-secondary: var(--color-text-secondary);
+    --color-icon-primary: var(--color-text-primary);
+
+    /* --- Reset button --- */
+    --reset-button-color: var(--color-text-primary);
+    --reset-button-border-color: var(--color-border-primary);
+
+    /* --- Layout --- */
+    --layout-color-bg: var(--color-bg-primary);
+
+    /* --- Notifications --- */
+    --notification-success-bg: #2e6b45;
+    --notification-success-text-color: #e8e8e8;
+    --notification-info-bg: #1a3a5c;
+    --notification-info-text-color: #e8e8e8;
+    --notification-warning-bg: #7a5418;
+    --notification-warning-text-color: #e8e8e8;
+    --notification-danger-bg: #6b2c2c;
+    --notification-danger-text-color: #e8e8e8;
+    --notification-default-bg: #2c2c2e;
+    --notification-default-text-color: var(--color-text-secondary);
+
+    /* --- Buttons --- */
+    --button-default-text-color: var(--color-text-secondary);
+    --button-default-bg-hover: rgba(255, 255, 255, 0.08);
+    --button-default-border: 1px solid var(--color-border-primary);
+    --button-default-active-text-color: var(--color-text-primary);
+    --button-default-active-bg: var(--color-bg-neutral);
+
+    --button-text-text-color: var(--color-text-primary);
+    --button-text-bg-hover: rgba(255, 255, 255, 0.05);
+    --button-text-active-text-color: var(--color-text-primary);
+    --button-text-active-bg: var(--color-bg-neutral);
+
+    --button-primaryText-text-color: var(--color-text-highlight);
+    --button-primaryText-bg-hover: rgba(74, 158, 255, 0.1);
+    --button-primaryText-border: 1px solid var(--color-text-highlight);
+    --button-primaryText-active-text-color: var(--color-text-highlight);
+    --button-primaryText-active-bg: rgba(74, 158, 255, 0.15);
+
+    /* --- Code block --- */
+    --code-bg: #1e1e1e;
+    --code-text-color: #d4d4d4;
+
+    /* --- Collapsable --- */
+    --collapsable-header-text-color: var(--color-text-primary);
+    --collapsable-header-open-text-color: var(--color-text-primary);
+    --collapsable-header-border-bottom: 1px solid var(--color-border-1);
+
+    /* --- Table --- */
+    --table-head-bg: #1a1a1a;
+    --table-head-text-color: var(--color-text-light);
+    --table-head-active-bg: #1a1a1a;
+    --table-head-active-text-color: var(--color-text-primary);
+
+    --table-cell-border: 1px solid #1a1a1a;
+    --table-cell-text-color: var(--color-text-primary);
+    --table-cell-bg: rgba(255, 255, 255, 0.03);
+    --table-cell-hover-bg: #1a3a5c;
+    --table-cell-hover-text-color: var(--color-text-highlight);
+
+    /* --- Tabs --- */
+    --tab-heading-text-color: var(--color-text-secondary);
+    --tab-heading-active-text-color: var(--color-text-primary);
+    --tab-heading-item-active-border-bottom: 2px solid var(--color-text-highlight);
+
+    /* --- Titled row --- */
+    --titled-row-head-text-color: var(--color-text-primary);
+    --titled-row-bg: rgba(255, 255, 255, 0.04);
+    --titled-row-text-color: var(--color-text-primary);
+    --titled-row-table-border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    --titled-row-table-separator-border: 1px solid rgba(255, 255, 255, 0.1);
+
+    /* --- Breadcrumb --- */
+    --breadcrumb-bg: #1e1e1e;
+    --breadcrumb-text-color: var(--color-text-primary);
+    --breadcrumb-border: 1px solid var(--color-text-highlight);
+    --breadcrumb-placeholder-color: #606060;
+    --breadcrumb-highlight-text-color: var(--color-text-primary);
+
+    /* --- Tooltip --- */
+    --tooltip-bg: rgba(30, 30, 30, 0.92);
+
+    /* --- Input --- */
+    --input-border: 1px solid var(--color-border-1);
+    --input-border-danger: 1px solid var(--color-bg-danger);
+    --input-text-color: var(--color-text-primary);
+    --input-bg: #1e1e1e;
+
+    /* --- Data header (the dark bar at top of task/run pages) --- */
+    --data-header-bg: #1e1e1e;
+    --data-header-text-color: #e8e8e8;
+    --data-header-label-text-color: #e8e8e8;
+    --data-header-link-color: #e8e8e8;
+
+    /* --- Popover --- */
+    --popover-border: 1px solid var(--color-border-primary);
+    --popover-shadow: 1px 1px 8px rgba(0, 0, 0, 0.6);
+    --popover-background: #1e1e1e;
+
+    /* --- Run tags --- */
+    --run-tag-text-color: var(--color-text-primary);
+
+    /* --- Run warning banner --- */
+    --run-warning-bg: #7a5418;
+    --run-warning-text-color: #e8e8e8;
+
+    /* --- Timeline --- */
+    --timeline-line-color-neutral: #4a4a4a;
+    --timeline-line-color-success: #2e6b45;
+    --timeline-line-color-running: #4a7a10;
+    --timeline-line-color-warning: #8a6120;
+    --timeline-line-color-danger: #8a3c3c;
+    --timeline-line-color-unknown: #4a4a4a;
+
+    --timeline-footer-bg: rgba(255, 255, 255, 0.04);
+    --timeline-footer-selected-bg: #1e1e1e;
+
+    /* --- DAG graph nodes --- */
+    --dag-node-bg: #1e1e1e;
+    --dag-container-bg: #252525;
+    --dag-foreach-bg: rgba(255, 255, 255, 0.06);
+
+    /* --- Overrides for components using hardcoded-ish tokens --- */
+    --color-text-alternative: #e8e8e8;
+    --input-text-color: var(--color-text-primary);
+
+    /* --- Table / property table borders (use subtle dark instead of thick white) --- */
+    --border-alternative-medium: 1px solid rgba(255, 255, 255, 0.1);
+
+    /* --- Log viewer, property table bright cells --- */
+    --log-viewer-bg: #181818;
+    --log-viewer-color: #d4d4d4;
+    --property-table-bright-bg: #252525;
+  }
+}
+
+/* =====================================================================
+   Dark Mode — Manual Toggle (data-theme="dark")
+   Mirrors the media-query dark tokens so that the JS toggle works
+   independent of the OS setting.  When data-theme="light" is set it
+   also explicitly resets everything so switching back to light works.
+   ====================================================================== */
+[data-theme='dark'] {
+  /* Keep html color-scheme in sync so native elements (scrollbars, inputs) go dark */
+  color-scheme: dark;
+
+  --color-primary: #4a9eff;
+  --color-secondary: #c8c8c8;
+  --color-tertiary: #00d4e8;
+
+  --color-bg-primary: #121212;
+  --color-bg-secondary: #1e1e1e;
+  --color-bg-heavy: #0a0a0a;
+  --color-bg-neutral: #252525;
+  --color-bg-secondary-highlight: #1a3a5c;
+
+  --color-text-primary: #e8e8e8;
+  --color-text-secondary: #a8a8a8;
+  --color-text-light: #888888;
+  --color-text-highlight: #4a9eff;
+
+  --color-border-primary: #2a2a2a;
+  --color-border-1: rgba(255, 255, 255, 0.06);
+  --color-border-2: rgba(255, 255, 255, 0.12);
+  --color-border-3: rgba(255, 255, 255, 0.2);
+
+  --color-success: #3a9e6a;
+  --color-warning: #c8840a;
+  --color-danger: #c0392b;
+
+  --color-success-bg: #0d2e1e;
+  --color-warning-bg: #2e1e00;
+  --color-danger-bg: #2e0d0d;
+
+  --color-success-text: #5abf8a;
+  --color-warning-text: #e8a030;
+  --color-danger-text: #e85050;
+
+  --input-bg: #1e1e1e;
+  --input-color: #e8e8e8;
+  --input-border: 1px solid #2a2a2a;
+  --input-placeholder-color: #606060;
+  --input-shadow: none;
+  --input-focus-shadow: 0 0 0 0.125rem rgba(74, 158, 255, 0.25);
+
+  /* Code / pre elements (e.g. JSON values in Details dropdown) */
+  --code-bg: #1e1e1e;
+  --code-text-color: #d4d4d4;
+
+  --layout-color-bg: #121212;
+  --layout-color-header-bg: #181818;
+  --layout-sidebar-bg: #1a1a1a;
+  --layout-sidebar-text-color: #c8c8c8;
+  --layout-sidebar-active-text-color: #4a9eff;
+  --layout-sidebar-border: 1px solid #2a2a2a;
+
+  --table-head-bg: #1a1a1a;
+  --table-head-text-color: #a8a8a8;
+  --table-border: 1px solid #2a2a2a;
+  --table-cell-border: 1px solid rgba(255, 255, 255, 0.1);
+  --table-odd-row-bg: #161616;
+  --table-even-row-bg: #1a1a1a;
+  --table-cell-hover-bg: #1a3a5c;
+  --table-cell-hover-text-color: #e8e8e8;
+
+  --button-default-bg: #1e1e1e;
+  --button-default-text-color: #c8c8c8;
+  --button-default-border: 1px solid #2a2a2a;
+  --button-default-bg-hover: rgba(255, 255, 255, 0.08);
+  --button-primary-bg: #4a9eff;
+  --button-primary-text-color: #121212;
+  --button-text-color: #4a9eff;
+  --button-text-bg-hover: rgba(255, 255, 255, 0.05);
+  --button-primaryText-text-color: #4a9eff;
+  --button-primaryText-bg-hover: rgba(74, 158, 255, 0.1);
+  --button-primaryText-border: 1px solid #4a9eff;
+  --button-primaryText-active-text-color: #4a9eff;
+  --button-primaryText-active-bg: rgba(74, 158, 255, 0.15);
+
+  --tab-active-color: #4a9eff;
+  --tab-inactive-color: #888888;
+  --tab-border-color: #2a2a2a;
+  --tab-active-border-color: #4a9eff;
+  --tab-bg: transparent;
+
+  --notification-success-bg: #0d2e1e;
+  --notification-success-border: 1px solid #2a6a45;
+  --notification-warning-bg: #2e1e00;
+  --notification-warning-border: 1px solid #8a5010;
+  --notification-danger-bg: #2e0d0d;
+  --notification-danger-border: 1px solid #8a2828;
+  --notification-default-bg: #1e1e1e;
+  --notification-default-border: 1px solid #2a2a2a;
+
+  --data-header-bg: #181818;
+  --data-header-border: 1px solid #2a2a2a;
+  --data-header-label-text-color: #e8e8e8;
+  --data-header-link-color: #e8e8e8;
+
+  --popover-border: 1px solid var(--color-border-primary);
+  --popover-shadow: 1px 1px 8px rgba(0, 0, 0, 0.6);
+  --popover-background: #1e1e1e;
+
+  --run-tag-text-color: var(--color-text-primary);
+  --run-warning-bg: #7a5418;
+  --run-warning-text-color: #e8e8e8;
+
+  --breadcrumb-bg: #1e1e1e;
+  --breadcrumb-text-color: var(--color-text-primary);
+  --breadcrumb-border: 1px solid var(--color-text-highlight);
+  --breadcrumb-placeholder-color: #606060;
+  --breadcrumb-highlight-text-color: var(--color-text-primary);
+
+  --timeline-line-color-neutral: #4a4a4a;
+  --timeline-line-color-success: #2e6b45;
+  --timeline-line-color-running: #4a7a10;
+  --timeline-line-color-warning: #8a6120;
+  --timeline-line-color-danger: #8a3c3c;
+  --timeline-line-color-unknown: #4a4a4a;
+  --timeline-footer-bg: rgba(255, 255, 255, 0.04);
+  --timeline-footer-selected-bg: #1e1e1e;
+
+  /* --- DAG graph nodes --- */
+  --dag-node-bg: #1e1e1e;
+  --dag-container-bg: #252525;
+  --dag-foreach-bg: rgba(255, 255, 255, 0.06);
+
+  /* --- Overrides for components using hardcoded-ish tokens --- */
+  --color-text-alternative: #e8e8e8;
+  --input-text-color: var(--color-text-primary);
+
+  /* --- Table / property table borders (use subtle dark instead of thick white) --- */
+  --border-alternative-medium: 1px solid rgba(255, 255, 255, 0.1);
+
+  /* --- Titled row (Details dropdown separators) --- */
+  --titled-row-head-text-color: var(--color-text-primary);
+  --titled-row-bg: rgba(255, 255, 255, 0.04);
+  --titled-row-text-color: var(--color-text-primary);
+  --titled-row-table-border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  --titled-row-table-separator-border: 1px solid rgba(255, 255, 255, 0.1);
+
+  /* --- Log viewer, property table bright cells --- */
+  --log-viewer-bg: #181818;
+  --log-viewer-color: #d4d4d4;
+  --property-table-bright-bg: #252525;
+}
+
+/* Reset for explicit light mode (when dark is active via OS but user switches back) */
+[data-theme='light'] {
+  color-scheme: light;
+  /* Restore ALL light-mode values that might be overridden by dark blocks.
+     Use explicit hex values (not var()) so they always win regardless of
+     whether the OS itself is dark (prefers-color-scheme: dark). */
+
+  /* Core colours */
+  --color-primary: #338ef7;
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: rgba(0, 0, 0, 0.03);
+  --color-bg-secondary-highlight: #e4f0ff;
+  --color-bg-heavy: #444;
+  --color-bg-neutral: #e8eaed;
+  --color-text-primary: #333333;
+  --color-text-secondary: #606060;
+  --color-text-light: #a0a0a0;
+  --color-text-highlight: #338ef7;
+  --color-border-1: rgba(0, 0, 0, 0.06);
+  --color-border-2: rgba(0, 0, 0, 0.12);
+  --color-border-3: rgba(0, 0, 0, 0.2);
+
+  /* Components */
+  --color-text-alternative: #ffffff;
+  --border-alternative-medium: 2px solid rgba(0, 0, 0, 0.08);
+  --input-text-color: #333333;
+  --input-bg: #ffffff;
+  --input-color: #333333;
+  --input-placeholder-color: #a0a0a0;
+  --code-bg: #f7f7f7;
+  --code-text-color: #333333;
+  --log-viewer-bg: #f0f0f0;
+  --log-viewer-color: #333333;
+  --property-table-bright-bg: #ffffff;
+  --table-cell-border: 1px solid #e0e0e0;
+  --titled-row-bg: rgba(0, 0, 0, 0.03);
+  --titled-row-text-color: #333333;
+  --titled-row-table-border-bottom: 1px solid #e0e0e0;
+  --titled-row-table-separator-border: 1px solid #e0e0e0;
+  --layout-color-bg: #f8f8f8;
+  --layout-color-header-bg: #ffffff;
+  --layout-sidebar-bg: #fafafa;
+  --layout-sidebar-text-color: #333333;
+  --popover-background: #ffffff;
 }

--- a/src/utils/testing.tsx
+++ b/src/utils/testing.tsx
@@ -7,6 +7,8 @@ import GlobalStyle from '../GlobalStyle';
 import '../theme/font/roboto.css';
 import './i18n';
 
+import { ThemeProvider } from '@components/ThemeProvider';
+
 // Mock PluginsContext for testing - provides stub functions for plugin communication
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
@@ -29,16 +31,18 @@ const TestWrapper: React.FC<{ children: ReactNode; route?: string }> = ({ childr
   return (
     <>
       <GlobalStyle />
-      <MemoryRouter initialEntries={[route]}>
-        <QueryParamProvider ReactRouterRoute={Route}>
-          <PluginsContext.Provider value={mockPluginsContextValue as never}>
-            <NotificationsProvider>
-              {children}
-              <Notifications />
-            </NotificationsProvider>
-          </PluginsContext.Provider>
-        </QueryParamProvider>
-      </MemoryRouter>
+      <ThemeProvider>
+        <MemoryRouter initialEntries={[route]}>
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <PluginsContext.Provider value={mockPluginsContextValue as never}>
+              <NotificationsProvider>
+                {children}
+                <Notifications />
+              </NotificationsProvider>
+            </PluginsContext.Provider>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </ThemeProvider>
     </>
   );
 };


### PR DESCRIPTION
### Requirements for a pull request

- [x] Unit tests related to the change have been updated <!-- write x between the brackets -->
- [x] Documentation related to the change has been updated <!-- write x between the brackets -->

### Description of the Change

This PR addresses the general implementation of the Dark Mode and several UI regressions and theme consistency issues. It focuses on ensuring parity between OS-level theme detection and manual theme toggling, while refining the visual style of tables, logs, inputs and more.

#### Key Changes

#### 1. Dark Mode Integration, Theme Consistency & Explicit Resets
 Metaflow UI is now fully themed for both light and dark modes. The implementation leverages the existing CSS variable architecture:
- **Automatic Detection**: Defaults to the user's OS preference (`prefers-color-scheme`).
- **Manual Toggle**: A Sun/Moon toggle has been added to the header (next to "Quick links") for explicit theme switching.
- **Persistence**: Theme selection is persisted to `localStorage`.
- **UI Polish**: Resolved issues where text was unreadable on hover in dark mode and fixed layout padding for the "Runs" heading on the home page (added 12px left padding).
- **Light Mode Fix**: Implemented a comprehensive `[data-theme='light']` reset block in [theme.css](cci:7://file:///Users/mac/Desktop/SOB/GSOC/metaflow/metaflow-ui/src/theme/theme.css:0:0-0:0). This ensures that when a user manually toggles to Light Mode on a machine with a Dark OS preference, all color primitives (text, backgrounds, inputs) are explicitly reset to their light-mode hex values rather than inheriting dark-mode variables.
- **Manual Toggle Parity**: Added dark-mode overrides for `--code-bg`, `--input-text-color`, and `--table-cell-border` to the explicit `[data-theme='dark']` block to ensure a consistent experience across both "Auto" and "Manual" dark modes.

#### 2. UI Polish & Aesthetics to fit Development
- **Subtle Table Borders**: Replaced thick white borders in the "Runs" table and other property tables with a subtle grey (`1px solid rgba(255, 255, 255, 0.1)`) in dark mode, matching a more modern, premium aesthetic.
- **Log Viewer Improvements**: Updated the log background to a custom light-grey (`#f5f5f5`) in light mode and a deep charcoal (`#181818`) in dark mode, providing better contrast and distinguishing logs from the main page background.
- **AppBar Alignment**: Aligned the Dark Mode toggle button height (`2.375rem`) precisely with the adjacent "Quick links" button to maintain a balanced header layout.
- **Parameter Table Fix**: Resolved a regression where JSON parameter values in the "Details" dropdown appeared inside white boxes; they now correctly use theme-aware surface tokens.

### Alternate Designs

- **Component-level state**: Considered adding a theme prop to every component, but selected the CSS variable + global attribute approach as it's cleaner, requires zero new component code, and is easier to maintain.

### Possible Drawbacks

- **Legacy browser support**: Older browsers that don't support CSS variables or media queries will continue to see the default light theme.

### Verification Results

The implementation has been verified for both Light/Dark modes and Auto/Manual toggling. Below are the key visual confirmations:

| Issue | Verification Screenshot |
| :--- | :--- |
| **Subtle Dark Borders** | <img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 51 55 PM" src="https://github.com/user-attachments/assets/08a22d67-7b91-4288-85a4-bcdd55f40acf" /> |
| **Input Text (Light/Dark) Compatible** | <img width="1416" height="304" alt="Screenshot 2026-03-24 at 9 56 33 PM" src="https://github.com/user-attachments/assets/debb5554-d875-4919-8084-4274ea842415" /> |
| **Theme-Aware Logs** | <img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 48 34 PM" src="https://github.com/user-attachments/assets/b5ffc76e-afcb-47ec-b042-a84e683b454d" /> |
| **Header Bar Theme Toggle** | <img width="305" height="111" alt="Screenshot 2026-03-24 at 10 01 11 PM" src="https://github.com/user-attachments/assets/2687c44b-133e-40f6-a8a4-f387436a9ff3" /> |
| **Details Dropdown** | <img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 50 45 PM" src="https://github.com/user-attachments/assets/2d8dbe46-0374-47e3-a4ef-0bc9398a10ea" /> |
| **DAG Graph** | <img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 49 20 PM" src="https://github.com/user-attachments/assets/23f972f5-89ce-434f-8523-a70da3578ddc" /> |
| **Debug Log Checks** | <img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 47 09 PM" src="https://github.com/user-attachments/assets/28c2e7d0-61a4-4499-93c9-f6df337f7286" /> |

### Related checks

The implementation has been verified for both Light/Dark modes and Auto/Manual toggling. Below are more key visual confirmations:

<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 43 23 PM" src="https://github.com/user-attachments/assets/7113922c-200d-4ae9-98d5-dcc6b20bff4d" />
<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 45 06 PM" src="https://github.com/user-attachments/assets/84fb4a06-f8ae-4239-bfda-d1ccef6c4491" />
<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 45 59 PM" src="https://github.com/user-attachments/assets/7381f564-4b8a-42be-9145-5bf143f38b79" />

<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 46 22 PM" src="https://github.com/user-attachments/assets/da5868a3-ed65-433e-9e94-24ec0ce76fde" />
<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 51 55 PM" src="https://github.com/user-attachments/assets/08a22d67-7b91-4288-85a4-bcdd55f40acf" />

<img width="1416" height="304" alt="Screenshot 2026-03-24 at 9 56 33 PM" src="https://github.com/user-attachments/assets/debb5554-d875-4919-8084-4274ea842415" />
<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 47 31 PM" src="https://github.com/user-attachments/assets/e12ced8d-b508-45f7-b79f-bddf58db0e58" />
<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 48 11 PM" src="https://github.com/user-attachments/assets/2e12bb42-c9e8-4c53-beba-0cbe30a92116" />

<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 48 34 PM" src="https://github.com/user-attachments/assets/b5ffc76e-afcb-47ec-b042-a84e683b454d" />

<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 49 20 PM" src="https://github.com/user-attachments/assets/23f972f5-89ce-434f-8523-a70da3578ddc" />

<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 50 12 PM" src="https://github.com/user-attachments/assets/066b12ea-6e6c-433f-8c40-2f0f9b505ac9" />
<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 50 45 PM" src="https://github.com/user-attachments/assets/2d8dbe46-0374-47e3-a4ef-0bc9398a10ea" />
<img width="1416" height="962" alt="Screenshot 2026-03-24 at 9 47 09 PM" src="https://github.com/user-attachments/assets/28c2e7d0-61a4-4499-93c9-f6df337f7286" />

### Related Issues

Closes the final set of UI polish requests for the Dark Mode integration in issue #157 