### PR TITLE
fix(mocks): use dynamic origin for MSW url (#177)

### DIFF
--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -2,7 +2,7 @@ import { HttpResponse, http, ws } from 'msw';
 import { setupWorker } from 'msw/browser';
 
 const stantardGetEndpoint = (endpoint, data) => {
-  const url = `http://localhost:3000/${endpoint}`;
+  const url = `${window.location.origin}/${endpoint}`;
 
   return http.get(url, () => {
     return HttpResponse.json({
@@ -28,7 +28,9 @@ const rawGetEndpoint = (url, data) => {
   });
 };
 
-const wsApi = ws.link('ws://localhost:3000/api/ws');
+const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+const wsUrl = `${wsProtocol}//${window.location.host}/api/ws`;
+const wsApi = ws.link(wsUrl);
 
 export const worker = setupWorker(
   stantardGetEndpoint('api/runs', [


### PR DESCRIPTION
### Description
Fixes #177. 

This PR resolves an issue where the Mock Service Worker (MSW) endpoints were hardcoded to `http://localhost:3000`. This caused mock intercept failures whenever the development server started on a different port (e.g. 3001, 3002), which often happens if port 3000 is already in use.

### Changes
- **Dynamic Origin Detection:** Replaced the hardcoded base URL with `window.location.origin` in `stantardGetEndpoint`.
- - **Protocol-Agnostic WebSockets:** Updated the WebSocket API setup to dynamically determine both the protocol (`ws:` or `wss:`) and the host from the current browser environment, ensuring compatibility across different deployment scenarios.
### Verification Results
This fix has been thoroughly tested locally:
- **Alternative Port Simulation:** Forced the development server to run on **Port 3002** using `$env:PORT="3002"; npm run start-with-mocks`.
- - **Automated Browser Audit:** Verified using a real browser to ensure MSW intercepted traffic correctly on port 3002.
- - **Confirmed Interception:** Inspected logs to verify that MSW successfully intercepted traffic on port 3002.
- - **WebSocket Validation:** Verified that the mock WebSocket connection correctly initialized and handled `__ping__` / `__pong__` messages using the dynamic host configuration.