### PR TITLE
feat: add pulse animation to running DAG nodes

### DIFF
--- a/src/components/DAG/components/DAGContent.tsx
+++ b/src/components/DAG/components/DAGContent.tsx
@@ -270,14 +270,36 @@ const StatusColorStyles = css<{ state: TaskStatus }>`
           : '#fff'};
 `;
 
+const pulseAnimation = css`
+  @keyframes dag-pulse {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in hsl, var(--color-text-warning) 40%, transparent);
+    }
+    70% {
+      box-shadow: 0 0 0 6px transparent;
+    }
+    100% {
+      box-shadow: 0 0 0 0 transparent;
+    }
+  }
+`;
+
 const NormalItem = styled.div<{ state: TaskStatus }>`
   ${StatusColorStyles}
+  ${pulseAnimation}
   padding: 0.75rem 1.5rem;
 
   position: relative;
   border-radius: var(--radius-primary);
   transition: 0.15s border;
   cursor: pointer;
+
+  ${(p) =>
+    p.state === 'running'
+      ? css`
+          animation: dag-pulse 2s infinite;
+        `
+      : ''}
 `;
 
 const BaseContainerStyle = css`


### PR DESCRIPTION
Running steps in the DAG view now pulse with a subtle box-shadow animation so users can see at a glance which steps are actively executing. Completed, failed, and unknown steps render without animation as before.

## What changed

Added a CSS keyframe animation (`dag-pulse`) to `NormalItem` in `DAGContent.tsx` that activates when `state === 'running'`. Uses the existing warning color variable for consistency with the running-state border.

## Files changed

- `src/components/DAG/components/DAGContent.tsx` -- pulse animation + conditional application

Partially addresses #89.