### PR TITLE
fix: adjust padding in VirtualizedTimeline for fullscreen mode

### DIFF
--- a/src/components/Timeline/VirtualizedTimeline.tsx
+++ b/src/components/Timeline/VirtualizedTimeline.tsx
@@ -122,7 +122,7 @@ const VirtualizedTimeline: React.FC<TimelineProps> = ({
   const handleSetFullScreen = () => setFullscreen(true);
 
   const content = (
-    <VirtualizedTimelineContainer style={showFullscreen ? { padding: '0 1rem' } : {}}>
+    <VirtualizedTimelineContainer style={showFullscreen ? { padding: '0.75rem 1rem 0 1rem' } : {}}>
       <VirtualizedTimelineSubContainer>
         <TaskListingHeader
           run={run}


### PR DESCRIPTION
### Requirements for a pull request

- [ ] Unit tests related to the change have been updated
- [ ] Documentation related to the change has been updated

### Description of the Change

Fixes an issue where floating labels in dropdown fields (e.g., "Mode", "Order by") were visually clipped in the fullscreen timeline view.

The issue occurred because the floating label uses a negative translate transform to move above the input field, while the fullscreen container applies `overflow: hidden`, causing the label to be partially cut off.

This change adds a small top padding to the fullscreen timeline container, ensuring sufficient space for the label to render correctly without modifying global input styles or layout behavior.

# The Issue (FullView mode)
<img width="513" height="52" alt="Screenshot from 2026-03-26 01-07-22" src="https://github.com/user-attachments/assets/5426b7ff-967d-449e-9a0a-f82e803f2ac0" />

# Fullscreen After Fix (Resolved)
<img width="1920" height="1080" alt="Screenshot from 2026-03-26 09-39-22" src="https://github.com/user-attachments/assets/c203c735-ff5e-4853-80fd-82c92debeab8" />

# Fullscreen Before Fix (Clipped Label)
<img width="1920" height="1080" alt="Screenshot from 2026-03-26 09-39-27" src="https://github.com/user-attachments/assets/98b6fbcf-345d-4dd3-99f4-926e4a0b1f3e" />

### Alternate Designs

- Removing `overflow: hidden` from the fullscreen container  
  → Not chosen as it could introduce unintended layout and scrolling issues.

- Modifying the global label transform (`--input-label-transform-active`)  
  → Not chosen because it would affect all input fields across the application.

- Using `overflow: visible` selectively  
  → Not chosen due to potential side effects with layout containment.

The selected approach (adding localized padding) is minimal, targeted, and avoids global impact.

### Possible Drawbacks

- Introduces a small additional spacing at the top of the fullscreen timeline container.
- If future UI changes rely on tight vertical spacing in this area, this padding may need adjustment.

### Verification Process

- Opened a flow run page:
  `http://localhost:3000/DemoFlow/2?direction=asc&group=true&order=startTime&status`

- Tested in **normal view**:
  - Verified dropdown labels ("Mode", "Order by") render correctly.

- Switched to **fullscreen view**:
  - Before fix: labels were clipped at the top.
  - After fix: labels render fully without clipping.

- Interacted with:
  - Dropdown open/close behavior
  - Filtering and ordering controls

- Confirmed:
  - No regression in layout
  - No overflow or scroll issues introduced
  - Consistent appearance between normal and fullscreen modes

### Release Notes

Fixed an issue where dropdown labels were clipped in fullscreen timeline view.