### PR TITLE
Add first-class dark mode with token hardening and plugin iframe theme sync (resolves #157)

### DIFF
--- a/src/components/DAG/components/DAGContent.tsx
+++ b/src/components/DAG/components/DAGContent.tsx
@@ -228,7 +228,7 @@ const Line = css`
     top: 0;
     width: 1px;
     height: 100%;
-    background: #d0d0d0;
+    background: var(--dag-line-color);
     left: 50%;
   }
 `;
@@ -262,12 +262,12 @@ const StatusColorStyles = css<{ state: TaskStatus }>`
             : 'var(--color-border-2)'};
   background: ${(p) =>
     p.state === 'completed'
-      ? 'color-mix(in hsl, var(--color-text-success) 5%, #fff)'
+      ? 'color-mix(in hsl, var(--color-text-success) 5%, var(--color-bg-primary))'
       : p.state === 'running'
-        ? 'color-mix(in hsl, var(--color-text-warning) 5%, #fff)'
+        ? 'color-mix(in hsl, var(--color-text-warning) 5%, var(--color-bg-primary))'
         : p.state === 'failed'
-          ? 'color-mix(in hsl, var(--color-text-danger) 5%, #fff)'
-          : '#fff'};
+          ? 'color-mix(in hsl, var(--color-text-danger) 5%, var(--color-bg-primary))'
+          : 'var(--color-bg-primary)'};
 `;
 
 const NormalItem = styled.div<{ state: TaskStatus }>`
@@ -282,7 +282,7 @@ const NormalItem = styled.div<{ state: TaskStatus }>`
 
 const BaseContainerStyle = css`
   border: var(--border-thin-2);
-  background: #f6f6f6;
+  background: var(--dag-panel-bg);
   display: flex;
   border-radius: var(--radius-secondary);
   position: relative;
@@ -295,14 +295,14 @@ const ContainerItem = styled.div`
 
 const ForeachContainer = styled.div`
   ${BaseContainerStyle}
-  background: rgba(192, 192, 192, 0.3);
+  background: var(--dag-split-outer-bg);
   transform: translateX(-0.275rem) translateY(-0.275rem);
   margin-top: 0.1875rem;
 `;
 
 const ForeachItem = styled.div`
   ${BaseContainerStyle}
-  background: #f6f6f6;
+  background: var(--dag-panel-bg);
   margin: 0;
   transform: translateX(0.275rem) translateY(0.275rem);
   flex: 1;
@@ -314,11 +314,11 @@ const StepInfoMarker = styled.div`
   right: 0.4rem;
 
   path {
-    fill: #717171;
+    fill: var(--color-text-secondary);
   }
 
   &:hover path {
-    fill: #333;
+    fill: var(--color-text-primary);
   }
 `;
 

--- a/src/components/HelpMenu/index.tsx
+++ b/src/components/HelpMenu/index.tsx
@@ -8,6 +8,7 @@ import TimezoneSelector from '@components/HelpMenu/TimezoneSelector';
 import Icon from '@components/Icon';
 import { PopoverWrapper } from '@components/Popover';
 import useOnKeyPress from '@hooks/useOnKeyPress';
+import { useTheme } from '@hooks/useTheme';
 import FEATURE_FLAGS from '@utils/FEATURE';
 import VERSION_INFO from '@utils/VERSION';
 import LaunchIconBlack from '@assets/launch_black.svg';
@@ -32,6 +33,7 @@ const HelpMenu: React.FC = () => {
   const [links, setLinks] = useState<HelpMenuLink[]>(DEFAULT_LINKS);
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
+  const { theme, toggleTheme } = useTheme();
 
   useOnKeyPress('Escape', () => setOpen(false));
 
@@ -70,6 +72,10 @@ const HelpMenu: React.FC = () => {
         <TimezoneSelectorContainer>
           <TimezoneSelector />
         </TimezoneSelectorContainer>
+
+        <HelpMenuItemButton onClick={toggleTheme} data-testid="helpmenu-toggle-theme">
+          {theme === 'dark' ? t('help.switch-light-mode') : t('help.switch-dark-mode')}
+        </HelpMenuItemButton>
 
         {INTERNAL_LINKS.map((link) => (
           <Link
@@ -194,6 +200,15 @@ const StyledHelpMenuLink = styled.a`
 
 const HelpMenuItem = styled.div`
   ${HelpMenuItemStyles}
+`;
+
+const HelpMenuItemButton = styled.button`
+  ${HelpMenuItemStyles}
+  background: transparent;
+  border: 0;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
 `;
 
 const HelpMenuClickOverlay = styled.div`

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -57,7 +57,7 @@ const ModalBackDrop = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.25);
+  background: var(--modal-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/Plugins/PluginGroup.tsx
+++ b/src/components/Plugins/PluginGroup.tsx
@@ -108,7 +108,7 @@ export const PluginHeader = styled.div`
   line-height: 1.5rem;
 
   svg path {
-    fill: #333;
+    fill: var(--color-text-primary);
   }
 `;
 

--- a/src/components/Plugins/PluginRegisterSystem.tsx
+++ b/src/components/Plugins/PluginRegisterSystem.tsx
@@ -54,6 +54,7 @@ const PluginRegisterSystem: React.FC<{ baseurl?: string }> = ({ baseurl }) => {
         return (
           <iframe
             key={plg.name}
+            data-mf-plugin={plg.name}
             height="0"
             width="0"
             name={plg.name}

--- a/src/components/Plugins/PluginSlot.tsx
+++ b/src/components/Plugins/PluginSlot.tsx
@@ -3,7 +3,9 @@ import { useLocation } from 'react-router';
 import styled from 'styled-components';
 import PLUGIN_STYLESHEET from '@components/Plugins/PluginDefaultStyleSheet';
 import { MESSAGE_NAME, Plugin, PluginCommunicationsAPI, PluginsContext } from '@components/Plugins/PluginManager';
+import { injectPluginThemeBootstrap } from '@components/Plugins/pluginThemeSync';
 import { TimezoneContext } from '@components/TimezoneProvider';
+import { useTheme } from '@hooks/useTheme';
 import { KnownURLParams, getRouteMatch } from '@utils/routing';
 
 //
@@ -33,6 +35,7 @@ const PluginSlot: React.FC<Props> = ({ id, url, title, plugin, resourceParams })
   const VERY_UNIQUE_ID = id + title + url;
   const route = useMemo(() => getRouteMatch(loc.pathname), [loc.pathname]);
   const { timezone } = useContext(TimezoneContext);
+  const { theme } = useTheme();
 
   const listener = useCallback(
     (e: MessageEvent) => {
@@ -46,15 +49,16 @@ const PluginSlot: React.FC<Props> = ({ id, url, title, plugin, resourceParams })
               resource: resourceParams ? resourceParams : route ? convertParams(route.params) : {},
               settings: {
                 timezone,
+                theme,
               },
             },
             '*',
           );
-          if (plugin.config.useApplicationStyles) {
-            const iframeContent = _iframe?.current?.contentDocument;
-            if (iframeContent) {
+          const iframeContent = _iframe?.current?.contentDocument;
+          if (iframeContent) {
+            injectPluginThemeBootstrap(iframeContent);
+            if (plugin.config.useApplicationStyles) {
               iframeContent.head.innerHTML = `<style>${PLUGIN_STYLESHEET}</style>` + iframeContent.head.innerHTML;
-              // TODO: ADD VARIABLES
             }
           }
         } else {
@@ -113,7 +117,18 @@ const PluginSlot: React.FC<Props> = ({ id, url, title, plugin, resourceParams })
         }
       }
     },
-    [VERY_UNIQUE_ID, callEvent, plugin, resourceParams, route, subscribeToDatastore, subscribeToEvent, title, timezone],
+    [
+      VERY_UNIQUE_ID,
+      callEvent,
+      plugin,
+      resourceParams,
+      route,
+      subscribeToDatastore,
+      subscribeToEvent,
+      theme,
+      title,
+      timezone,
+    ],
   );
   //
   // Subscribe to messages from iframe
@@ -137,6 +152,7 @@ const PluginSlot: React.FC<Props> = ({ id, url, title, plugin, resourceParams })
       <iframe
         key={VERY_UNIQUE_ID}
         ref={_iframe}
+        data-mf-plugin={title}
         height={height}
         name={title}
         title={title}

--- a/src/components/Plugins/pluginThemeSync.ts
+++ b/src/components/Plugins/pluginThemeSync.ts
@@ -1,0 +1,54 @@
+import type { Theme } from '@/contexts/ThemeContext';
+
+export const MF_THEME_CHANGE = 'MF_THEME_CHANGE' as const;
+
+/**
+ * Notify all plugin iframes that the host theme changed.
+ * Uses each iframe's document origin as targetOrigin when src is set (works for same- and cross-origin);
+ * falls back to the host origin.
+ */
+export function broadcastThemeToPluginIframes(theme: Theme): void {
+  document.querySelectorAll<HTMLIFrameElement>('iframe[data-mf-plugin]').forEach((iframe) => {
+    const win = iframe.contentWindow;
+    if (!win) return;
+
+    let targetOrigin = window.location.origin;
+    try {
+      if (iframe.src) {
+        targetOrigin = new URL(iframe.src, window.location.href).origin;
+      }
+    } catch {
+      // keep host origin
+    }
+
+    win.postMessage({ type: MF_THEME_CHANGE, theme }, targetOrigin);
+  });
+}
+
+/**
+ * Minimal bootstrap for plugin iframes: mirror parent theme when allowed, then listen for updates.
+ * Injected via DOM (not innerHTML) so the script executes.
+ */
+const PLUGIN_THEME_BOOTSTRAP_IIFE = `(function(){
+  function applyTheme(t) {
+    if (t === 'light' || t === 'dark') document.documentElement.dataset.theme = t;
+  }
+  try {
+    var pel = window.parent && window.parent.document && window.parent.document.documentElement;
+    if (pel && pel.dataset && pel.dataset.theme) applyTheme(pel.dataset.theme);
+  } catch (e) {}
+  window.addEventListener('message', function(e) {
+    if (e.source !== window.parent) return;
+    if (e.data && e.data.type === '${MF_THEME_CHANGE}' && (e.data.theme === 'light' || e.data.theme === 'dark')) {
+      applyTheme(e.data.theme);
+    }
+  });
+})();`;
+
+export function injectPluginThemeBootstrap(doc: Document): void {
+  if (doc.getElementById('mf-plugin-theme-bootstrap')) return;
+  const script = doc.createElement('script');
+  script.id = 'mf-plugin-theme-bootstrap';
+  script.textContent = PLUGIN_THEME_BOOTSTRAP_IIFE;
+  doc.head.insertBefore(script, doc.head.firstChild);
+}

--- a/src/components/RenderMetadata/index.tsx
+++ b/src/components/RenderMetadata/index.tsx
@@ -30,7 +30,7 @@ const RenderMetadata: React.FC<Props> = ({ metadata }) => {
 const TemplateSlot = styled.div`
   padding: 0.5rem 0;
   margin-bottom: 0.5rem;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.03);
+  border-bottom: var(--border-thin-1);
 
   &:last-child {
     margin-bottom: 0;
@@ -44,10 +44,10 @@ const TemplateSlot = styled.div`
   }
 
   th {
-    background: #333;
-    color: #fff;
-    border-right: 2px solid #fff;
-    border-bottom: 2px solid #fff;
+    background: var(--metadata-table-header-bg);
+    color: var(--metadata-table-header-text);
+    border-right: 2px solid var(--metadata-table-cell-border);
+    border-bottom: 2px solid var(--metadata-table-cell-border);
     font-size: var(--font-size-primary);
     padding: 0.4rem 1rem;
     font-weight: 400;
@@ -65,9 +65,9 @@ const TemplateSlot = styled.div`
   td {
     padding: 0.75rem 1rem;
     font-size: var(--font-size-primary);
-    border-right: 2px solid #fff;
-    border-bottom: 2px solid #fff;
-    background: rgba(0, 0, 0, 0.03);
+    border-right: 2px solid var(--metadata-table-cell-border);
+    border-bottom: 2px solid var(--metadata-table-cell-border);
+    background: var(--metadata-table-cell-bg);
   }
 `;
 

--- a/src/components/Timeline/TimelineRow/LineElement.tsx
+++ b/src/components/Timeline/TimelineRow/LineElement.tsx
@@ -201,12 +201,11 @@ const BoxGraphicLine = styled.div<{ grayed?: boolean; state: string; isLastAttem
         position: absolute;
         width: 100%;
         height: 200%;
-        background: rgb(255, 255, 255, 0.8);
         background: linear-gradient(
           90deg,
-          rgba(255, 255, 255, 0) 0%,
-          rgba(255, 255, 255, 0.5) 50%,
-          rgba(255, 255, 255, 0) 100%
+          var(--timeline-refine-shimmer-edge) 0%,
+          var(--timeline-refine-shimmer-mid) 50%,
+          var(--timeline-refine-shimmer-edge) 100%
         );
         top: -50%;
         left: 0;

--- a/src/components/Timeline/VirtualizedTimeline.tsx
+++ b/src/components/Timeline/VirtualizedTimeline.tsx
@@ -122,7 +122,7 @@ const VirtualizedTimeline: React.FC<TimelineProps> = ({
   const handleSetFullScreen = () => setFullscreen(true);
 
   const content = (
-    <VirtualizedTimelineContainer style={showFullscreen ? { padding: '0 1rem' } : {}}>
+    <VirtualizedTimelineContainer style={showFullscreen ? { padding: '0.75rem 1rem 0 1rem' } : {}}>
       <VirtualizedTimelineSubContainer>
         <TaskListingHeader
           run={run}

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -29,13 +29,13 @@ const CustomTooltip = styled.div`
   .custom-tooltip {
     cursor: auto;
     max-width: 37.5rem;
-    background: #fff;
-    color: #333;
+    background: var(--tooltip-surface-bg);
+    color: var(--tooltip-surface-text);
     padding: 1rem;
     font-size: 0.75rem;
     border-radius: var(--radius-primary);
-    border: 1px solid #d0d0d0;
-    box-shadow: 2px 2px 4px rgb(0 0 0 / 25%);
+    border: var(--tooltip-surface-border);
+    box-shadow: var(--tooltip-surface-shadow);
     white-space: pre;
     pointer-events: auto;
 
@@ -45,8 +45,8 @@ const CustomTooltip = styled.div`
 
     &.place-bottom::after,
     &.place-top::after {
-      border-bottom-color: #fff;
-      background: #fff;
+      border-bottom-color: var(--tooltip-surface-bg);
+      background: var(--tooltip-surface-bg);
     }
     &:hover {
       visibility: visible;
@@ -60,7 +60,7 @@ const CustomTooltip = styled.div`
 //
 
 export const TooltipTitle = styled.div`
-  margin-bottom 0.5rem;
+  margin-bottom: 0.5rem;
   font-weight: 500;
 `;
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { broadcastThemeToPluginIframes } from '@/components/Plugins/pluginThemeSync';
 
 export type Theme = 'light' | 'dark';
 
@@ -27,6 +28,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
     localStorage.setItem(THEME_STORAGE_KEY, theme);
+    broadcastThemeToPluginIframes(theme);
   }, [theme]);
 
   const toggleTheme = useCallback(() => {

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'mf-theme';
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const resolveInitialTheme = (): Theme => {
+  const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+  if (savedTheme === 'light' || savedTheme === 'dark') {
+    return savedTheme;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(resolveInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((oldTheme) => (oldTheme === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used inside ThemeProvider');
+  }
+
+  return context;
+};
+
+export { THEME_STORAGE_KEY };

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,1 @@
+export { useTheme } from '@/contexts/ThemeContext';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,23 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from '@/App';
+import { THEME_STORAGE_KEY, ThemeProvider, Theme } from '@/contexts/ThemeContext';
 import '@utils/VERSION';
 import '@utils/i18n';
 import { worker } from './mocks/browser';
+
+const hydrateTheme = () => {
+  const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+  const resolvedTheme: Theme =
+    savedTheme === 'light' || savedTheme === 'dark'
+      ? savedTheme
+      : window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+  document.documentElement.dataset.theme = resolvedTheme;
+};
+
+hydrateTheme();
 
 const container = document.getElementById('root');
 if (container) {
@@ -15,9 +29,17 @@ if (container) {
         onUnhandledRequest: 'bypass',
       })
       .then(() => {
-        root.render(<App />);
+        root.render(
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>,
+        );
       });
   } else {
-    root.render(<App />);
+    root.render(
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>,
+    );
   }
 }

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -427,6 +427,30 @@
   --task-content-border-right: none;
 
   --loglist-button-size: 2.5rem;
+
+  /* Modal */
+  --modal-backdrop: rgba(0, 0, 0, 0.25);
+
+  /* Solid tooltip (react-tooltip custom class) — distinct from translucent --tooltip-bg */
+  --tooltip-surface-bg: var(--color-bg-primary);
+  --tooltip-surface-text: var(--color-text-primary);
+  --tooltip-surface-border: var(--border-thin-1);
+  --tooltip-surface-shadow: var(--popover-shadow);
+
+  /* DAG panels */
+  --dag-line-color: var(--color-border-primary);
+  --dag-panel-bg: #f6f6f6;
+  --dag-split-outer-bg: rgba(192, 192, 192, 0.3);
+
+  /* Metadata markdown tables */
+  --metadata-table-header-bg: var(--color-bg-heavy);
+  --metadata-table-header-text: var(--color-text-alternative);
+  --metadata-table-cell-bg: var(--color-bg-secondary);
+  --metadata-table-cell-border: var(--color-bg-primary);
+
+  /* Timeline “refining” shimmer */
+  --timeline-refine-shimmer-mid: rgba(255, 255, 255, 0.5);
+  --timeline-refine-shimmer-edge: rgba(255, 255, 255, 0);
 }
 
 [data-theme='dark'] {
@@ -465,4 +489,14 @@
   --popover-border: 1px solid #3a414d;
   --popover-shadow: 1px 1px 10px rgba(0, 0, 0, 0.6);
   --timeline-line-color-neutral: #5b6473;
+
+  --modal-backdrop: rgba(0, 0, 0, 0.55);
+
+  --dag-panel-bg: var(--color-bg-secondary);
+  --dag-split-outer-bg: rgba(255, 255, 255, 0.06);
+
+  --metadata-table-cell-border: var(--color-bg-primary);
+
+  --timeline-refine-shimmer-mid: rgba(255, 255, 255, 0.22);
+  --timeline-refine-shimmer-edge: rgba(255, 255, 255, 0);
 }

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -428,3 +428,41 @@
 
   --loglist-button-size: 2.5rem;
 }
+
+[data-theme='dark'] {
+  --brand-color-secondary: #e7e7e7;
+
+  --color-bg-primary: #15171b;
+  --color-bg-secondary: #1f2228;
+  --color-bg-secondary-highlight: #1d2f4f;
+  --color-bg-heavy: #0f1115;
+  --color-bg-neutral: #2a2e37;
+  --color-bg-disabled: #8a919d;
+
+  --color-border-primary: #3a414d;
+  --color-border-1: rgba(255, 255, 255, 0.14);
+  --color-border-2: rgba(255, 255, 255, 0.25);
+  --color-border-3: rgba(255, 255, 255, 0.38);
+
+  --color-text-primary: #e8ebef;
+  --color-text-secondary: #bac1cb;
+  --color-text-light: #9ea6b2;
+  --color-text-alternative: #ffffff;
+  --color-text-highlight: #77abff;
+
+  --color-icon-light: #9ea6b2;
+
+  --button-default-bg-hover: rgba(255, 255, 255, 0.06);
+  --button-text-bg-hover: rgba(255, 255, 255, 0.06);
+  --button-primaryText-bg-hover: rgba(119, 171, 255, 0.18);
+
+  --code-bg: #1b1f26;
+  --table-cell-border: 1px solid #15171b;
+  --titled-row-table-border-bottom: 2px solid #15171b;
+  --titled-row-table-separator-border: 2px solid #15171b;
+  --breadcrumb-placeholder-color: #8f98a6;
+  --tooltip-bg: rgba(22, 24, 29, 0.95);
+  --popover-border: 1px solid #3a414d;
+  --popover-shadow: 1px 1px 10px rgba(0, 0, 0, 0.6);
+  --timeline-line-color-neutral: #5b6473;
+}

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -32,6 +32,8 @@ const en = {
       help: 'Help',
       'application-version': 'Application version',
       'service-version': 'Service version',
+      'switch-dark-mode': 'Switch to dark mode',
+      'switch-light-mode': 'Switch to light mode',
     },
 
     fields: {


### PR DESCRIPTION
resolves #157

### Requirements for a pull request

- [ ] Unit tests related to the change have been updated
- [ ] Documentation related to the change has been updated

### Description of the Change

This PR implements dark mode in a phased, production-safe way across host UI and plugin iframes.

1. **Theme foundation**
   - Added theme runtime state (`light | dark`) with persistence (`localStorage` key: `mf-theme`).
   - Added pre-mount hydration in `src/index.tsx` to prevent initial light flash.
   - Added theme toggle in Help menu.
   - Added dark token scope via `[data-theme='dark']`.

2. **Token hardening**
   - Replaced hardcoded colors in high-visibility components with semantic tokens:
     - `Modal`, `Tooltip`, `DAGContent`, `RenderMetadata`, `TimelineRow/LineElement`, `PluginGroup`.
   - Added new semantic tokens for modal/tooltip/DAG/metadata/shimmer surfaces and dark overrides.

3. **Plugin theme synchronization**
   - Added host-to-plugin theme broadcast (`MF_THEME_CHANGE`).
   - Added deterministic plugin iframe selector (`data-mf-plugin`).
   - Injected plugin bootstrap listener to apply initial theme and stay synced on runtime changes.
   - Extended `ReadyToRender.settings` with `theme` (in addition to `timezone`).
   
   
<img width="1920" height="1080" alt="Screenshot from 2026-03-26 11-41-53" src="https://github.com/user-attachments/assets/ccaeb7c4-15d9-4c9f-93d2-9dd0438133df" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-26 11-42-05" src="https://github.com/user-attachments/assets/7a8b3042-7447-49d4-9a5b-0f6e71d22f0c" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-26 11-42-11" src="https://github.com/user-attachments/assets/2cd8c04c-c943-4751-a1cf-b5273ed24628" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-26 11-42-18" src="https://github.com/user-attachments/assets/0f8a728c-9c66-4a8a-b80e-4e9de1b9b620" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-26 11-42-22" src="https://github.com/user-attachments/assets/ddaf165b-40da-4b7c-adf2-79936d10b7f4" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-26 11-42-34" src="https://github.com/user-attachments/assets/7e1074ec-46b5-432b-9d4c-38aeaa9a199b" />


### Alternate Designs

- **Styled-components `ThemeProvider` object migration** was considered but not chosen.
  - Reason: current codebase is already CSS-variable-first, so `data-theme` + token overrides is lower-risk and lower-churn.
- **Wildcard `postMessage` targetOrigin** was considered but not used as primary path.
  - Reason: this PR resolves target origin from iframe `src` when available, with safe fallback.

### Possible Drawbacks

- Some visual surfaces may need follow-up token tuning (especially DAG foreach tint/shimmer contrast) after broader UX review.
- Plugin theme sync relies on postMessage contract and iframe bootstrap script; third-party plugins with strict assumptions may need adaptation.
- Unit tests were not added in this PR; current validation is build + manual verification.

### Verification Process

- Ran lint checks on modified files (`ReadLints`) and fixed formatting/import-order issues.
- Ran production build after each major phase:
  - `yarn build`
  - Result: compiled successfully.
- Manual verification checklist:
  - Toggle theme from Help menu and confirm immediate host UI update.
  - Reload page and confirm persisted theme is applied on first paint (no flash).
  - Verify key hardened surfaces in dark mode:
    - Tooltip panel and arrow
    - Modal backdrop and content contrast
    - DAG nodes/containers/icons
    - Metadata markdown tables
    - Timeline refining shimmer
    - Plugin header icon color
  - Verify plugin iframes receive and apply theme updates on toggle.

### Release Notes

Added first-class dark mode support with persisted theme preference, tokenized UI styling for core views, and plugin iframe theme synchronization.