### PR TITLE
fix(debug): fix malformed log filename and persist HTTP warnings to IndexedDB (#181)

### DIFF
--- a/src/utils/debugdb.ts
+++ b/src/utils/debugdb.ts
@@ -57,6 +57,6 @@ export function setLogItem(str: string): void {
 export async function getLogs(): Promise<void> {
   if (db) {
     const all = await db.getAll('logs' as never);
-    downloadString(all.join('\n'), 'text/plain', `logs-${new Date().toISOString()}}.txt`);
+    downloadString(all.join('\n'), 'text/plain', `logs-${new Date().toISOString()}.txt`);
   }
 }

--- a/src/utils/errorlogger.ts
+++ b/src/utils/errorlogger.ts
@@ -1,6 +1,6 @@
-// import { getVersionInfo } from './VERSION';
+import { setLogItem } from './debugdb';
 
 export function logWarning(str: string, ...arg: unknown[]): void {
   console.warn(str, ...arg);
-  // console.log('Version information: ', getVersionInfo());
+  setLogItem(`WARN ${str}${arg.length ? ' ' + JSON.stringify(arg) : ''}`);
 }


### PR DESCRIPTION
Fixes #181.

### Description
This PR resolves two related defects in the client-side debug logging infrastructure:

**Bug 1 - Malformed log filename (debugdb.ts):**
The getLogs() function had a stray } at the end of the template literal, producing filenames like logs-2025-01-01T00:00:00.000Z}.txt. Removed the extra }.

**Bug 2 - HTTP warnings missing from debug log (errorlogger.ts):**
logWarning() only called console.warn, never writing to the IndexedDB debug log via setLogItem. This meant downloaded crash reports were missing the most useful diagnostic entries. Fixed by importing setLogItem from debugdb and calling it inside logWarning to persist all warnings to the persistent log.

### Changes
- src/utils/debugdb.ts - Removed stray } from filename template literal.
- - src/utils/errorlogger.ts - Added setLogItem call to persist warnings to IndexedDB debug log.
### Verification
1. Enabled debug mode and triggered a failing API request.
2. 2. Downloaded logs - filename is now correctly formatted (logs-<ISO timestamp>.txt).
3. 3. Opened the log file - confirmed "WARN HTTP error id: ..." entries are present.