### PR TITLE
feat: add run comparison type definitions and diff engine

### DIFF
--- a/src/types/comparison.ts
+++ b/src/types/comparison.ts
@@ -1,0 +1,75 @@
+import { Run, RunParam, Step, Task, TaskStatus } from '@/types';
+
+//
+// Run Comparison Types
+//
+// All fields are sourced from existing API endpoints — no new backend routes required.
+//
+//   RunSnapshot.run         → GET /flows/{flow_id}/runs/{run_number}
+//   RunSnapshot.parameters  → GET /flows/{flow_id}/runs/{run_number}/parameters
+//   RunSnapshot.steps       → GET /flows/{flow_id}/runs/{run_number}/steps
+//   StepSnapshot.tasks      → GET /flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks
+//   StepSnapshot.artifacts  → GET /flows/{flow_id}/runs/{run_number}/steps/{step_name}/tasks/{task_id}/artifacts
+//
+
+/**
+ * Snapshot of a single run with its parameters and step data.
+ * Built by assembling responses from existing endpoints.
+ */
+export type RunSnapshot = {
+  run: Run;
+  parameters: RunParam;
+  steps: StepSnapshot[];
+};
+
+/**
+ * Snapshot of a single step within a run.
+ * Status is derived from the step's tasks using getStepStatus (taskdataUtils.ts).
+ */
+export type StepSnapshot = {
+  step: Step;
+  status: TaskStatus;
+  tasks: Task[];
+  artifact_keys: string[];
+};
+
+/**
+ * Top-level comparison container for two runs.
+ */
+export type RunComparisonData = {
+  runA: RunSnapshot;
+  runB: RunSnapshot;
+};
+
+//
+// Derived diffs — computed client-side from RunComparisonData, never fetched.
+//
+
+export type RunDiff = {
+  params: ParamDiff[];
+  steps: StepDiff[];
+  artifacts: ArtifactDiff[];
+};
+
+export type ParamDiff = {
+  key: string;
+  valueA: string | undefined;
+  valueB: string | undefined;
+  changed: boolean;
+};
+
+export type StepDiff = {
+  step_name: string;
+  durationA: number | null;
+  durationB: number | null;
+  delta_ms: number | null;
+  statusA: TaskStatus;
+  statusB: TaskStatus;
+};
+
+export type ArtifactDiff = {
+  step_name: string;
+  key: string;
+  inA: boolean;
+  inB: boolean;
+};

--- a/src/utils/__tests__/comparison.test.cypress.ts
+++ b/src/utils/__tests__/comparison.test.cypress.ts
@@ -1,0 +1,170 @@
+import { computeParamDiffs, computeStepDiffs, computeArtifactDiffs, computeRunDiff } from '../comparison';
+import { createRun, createStep, createTask } from '../testhelper';
+import { RunComparisonData } from '@/types/comparison';
+import { RunParam } from '@/types';
+
+//
+// Test helpers
+//
+
+function makeSnapshot(
+  runOverrides: Parameters<typeof createRun>[0],
+  params: RunParam,
+  steps: { stepName: string; status: string; duration?: number; artifacts?: string[] }[],
+) {
+  return {
+    run: createRun(runOverrides),
+    parameters: params,
+    steps: steps.map((s) => ({
+      step: createStep({ step_name: s.stepName, duration: s.duration }),
+      status: s.status as any,
+      tasks: [createTask({ step_name: s.stepName, status: s.status as any })],
+      artifact_keys: s.artifacts ?? [],
+    })),
+  };
+}
+
+//
+// Tests
+//
+
+describe('comparison.ts — computeParamDiffs', () => {
+  it('identical params produce no changes', () => {
+    const params: RunParam = { alpha: { value: '0.01' }, epochs: { value: '10' } };
+    const diffs = computeParamDiffs(params, params);
+
+    expect(diffs.length).to.equal(2);
+    diffs.forEach((d) => expect(d.changed).to.equal(false));
+  });
+
+  it('detects changed values', () => {
+    const a: RunParam = { alpha: { value: '0.01' } };
+    const b: RunParam = { alpha: { value: '0.001' } };
+    const diffs = computeParamDiffs(a, b);
+
+    expect(diffs.length).to.equal(1);
+    expect(diffs[0].changed).to.equal(true);
+    expect(diffs[0].valueA).to.equal('0.01');
+    expect(diffs[0].valueB).to.equal('0.001');
+  });
+
+  it('handles params present in only one run', () => {
+    const a: RunParam = { alpha: { value: '0.01' } };
+    const b: RunParam = { beta: { value: '0.9' } };
+    const diffs = computeParamDiffs(a, b);
+
+    expect(diffs.length).to.equal(2);
+    const alpha = diffs.find((d) => d.key === 'alpha')!;
+    const beta = diffs.find((d) => d.key === 'beta')!;
+
+    expect(alpha.valueA).to.equal('0.01');
+    expect(alpha.valueB).to.equal(undefined);
+    expect(alpha.changed).to.equal(true);
+    expect(beta.valueA).to.equal(undefined);
+    expect(beta.valueB).to.equal('0.9');
+    expect(beta.changed).to.equal(true);
+  });
+
+  it('empty params produce empty diffs', () => {
+    expect(computeParamDiffs({}, {}).length).to.equal(0);
+  });
+});
+
+describe('comparison.ts — computeStepDiffs', () => {
+  it('computes duration delta between matching steps', () => {
+    const data: RunComparisonData = {
+      runA: makeSnapshot({ run_number: 1 }, {}, [{ stepName: 'train', status: 'completed', duration: 5000 }]),
+      runB: makeSnapshot({ run_number: 2 }, {}, [{ stepName: 'train', status: 'completed', duration: 3000 }]),
+    };
+    const diffs = computeStepDiffs(data);
+
+    expect(diffs.length).to.equal(1);
+    expect(diffs[0].step_name).to.equal('train');
+    expect(diffs[0].delta_ms).to.equal(-2000); // run B was 2s faster
+  });
+
+  it('handles steps present in only one run', () => {
+    const data: RunComparisonData = {
+      runA: makeSnapshot({ run_number: 1 }, {}, [{ stepName: 'start', status: 'completed' }]),
+      runB: makeSnapshot({ run_number: 2 }, {}, [{ stepName: 'end', status: 'completed' }]),
+    };
+    const diffs = computeStepDiffs(data);
+
+    expect(diffs.length).to.equal(2);
+    const startDiff = diffs.find((d) => d.step_name === 'start')!;
+    expect(startDiff.statusA).to.equal('completed');
+    expect(startDiff.statusB).to.equal('unknown');
+  });
+
+  it('null delta when either duration is missing', () => {
+    const data: RunComparisonData = {
+      runA: makeSnapshot({ run_number: 1 }, {}, [{ stepName: 'train', status: 'running' }]),
+      runB: makeSnapshot({ run_number: 2 }, {}, [{ stepName: 'train', status: 'completed', duration: 3000 }]),
+    };
+    const diffs = computeStepDiffs(data);
+
+    expect(diffs[0].delta_ms).to.equal(null);
+  });
+});
+
+describe('comparison.ts — computeArtifactDiffs', () => {
+  it('detects artifacts present in both runs', () => {
+    const data: RunComparisonData = {
+      runA: makeSnapshot({ run_number: 1 }, {}, [{ stepName: 'train', status: 'completed', artifacts: ['model', 'loss'] }]),
+      runB: makeSnapshot({ run_number: 2 }, {}, [{ stepName: 'train', status: 'completed', artifacts: ['model', 'loss'] }]),
+    };
+    const diffs = computeArtifactDiffs(data);
+
+    expect(diffs.length).to.equal(2);
+    diffs.forEach((d) => {
+      expect(d.inA).to.equal(true);
+      expect(d.inB).to.equal(true);
+    });
+  });
+
+  it('detects artifacts present in only one run', () => {
+    const data: RunComparisonData = {
+      runA: makeSnapshot({ run_number: 1 }, {}, [{ stepName: 'train', status: 'completed', artifacts: ['model'] }]),
+      runB: makeSnapshot({ run_number: 2 }, {}, [{ stepName: 'train', status: 'completed', artifacts: ['model', 'metrics'] }]),
+    };
+    const diffs = computeArtifactDiffs(data);
+    const metricsDiff = diffs.find((d) => d.key === 'metrics')!;
+
+    expect(metricsDiff.inA).to.equal(false);
+    expect(metricsDiff.inB).to.equal(true);
+  });
+
+  it('handles empty artifact lists', () => {
+    const data: RunComparisonData = {
+      runA: makeSnapshot({ run_number: 1 }, {}, [{ stepName: 'start', status: 'completed', artifacts: [] }]),
+      runB: makeSnapshot({ run_number: 2 }, {}, [{ stepName: 'start', status: 'completed', artifacts: [] }]),
+    };
+    const diffs = computeArtifactDiffs(data);
+
+    expect(diffs.length).to.equal(0);
+  });
+});
+
+describe('comparison.ts — computeRunDiff', () => {
+  it('produces a complete diff from two run snapshots', () => {
+    const data: RunComparisonData = {
+      runA: makeSnapshot(
+        { run_number: 1 },
+        { lr: { value: '0.01' } },
+        [{ stepName: 'train', status: 'completed', duration: 5000, artifacts: ['model'] }],
+      ),
+      runB: makeSnapshot(
+        { run_number: 2 },
+        { lr: { value: '0.001' } },
+        [{ stepName: 'train', status: 'completed', duration: 3000, artifacts: ['model', 'metrics'] }],
+      ),
+    };
+    const diff = computeRunDiff(data);
+
+    expect(diff.params.length).to.equal(1);
+    expect(diff.params[0].changed).to.equal(true);
+    expect(diff.steps.length).to.equal(1);
+    expect(diff.steps[0].delta_ms).to.equal(-2000);
+    expect(diff.artifacts.length).to.equal(2);
+  });
+});

--- a/src/utils/__tests__/comparison.test.cypress.ts
+++ b/src/utils/__tests__/comparison.test.cypress.ts
@@ -105,6 +105,27 @@ describe('comparison.ts — computeStepDiffs', () => {
 
     expect(diffs[0].delta_ms).to.equal(null);
   });
+
+  it('returns steps sorted alphabetically by step_name', () => {
+    const data: RunComparisonData = {
+      runA: makeSnapshot({ run_number: 1 }, {}, [
+        { stepName: 'train', status: 'completed', duration: 1000 },
+        { stepName: 'end', status: 'completed', duration: 500 },
+        { stepName: 'start', status: 'completed', duration: 200 },
+      ]),
+      runB: makeSnapshot({ run_number: 2 }, {}, [
+        { stepName: 'train', status: 'completed', duration: 2000 },
+        { stepName: 'end', status: 'completed', duration: 600 },
+        { stepName: 'start', status: 'completed', duration: 300 },
+      ]),
+    };
+    const diffs = computeStepDiffs(data);
+
+    expect(diffs.length).to.equal(3);
+    expect(diffs[0].step_name).to.equal('end');
+    expect(diffs[1].step_name).to.equal('start');
+    expect(diffs[2].step_name).to.equal('train');
+  });
 });
 
 describe('comparison.ts — computeArtifactDiffs', () => {

--- a/src/utils/comparison.ts
+++ b/src/utils/comparison.ts
@@ -1,0 +1,109 @@
+import { RunParam } from '@/types';
+import {
+  ArtifactDiff,
+  ParamDiff,
+  RunComparisonData,
+  RunDiff,
+  StepDiff,
+} from '@/types/comparison';
+
+/**
+ * Compute the full diff between two run snapshots.
+ * All diffing is client-side — no additional API calls needed.
+ */
+export function computeRunDiff(data: RunComparisonData): RunDiff {
+  return {
+    params: computeParamDiffs(data.runA.parameters, data.runB.parameters),
+    steps: computeStepDiffs(data),
+    artifacts: computeArtifactDiffs(data),
+  };
+}
+
+/**
+ * Compare parameters between two runs.
+ * Keys present in either run are included; changed flag indicates a value difference.
+ */
+export function computeParamDiffs(paramsA: RunParam, paramsB: RunParam): ParamDiff[] {
+  const allKeys = new Set([...Object.keys(paramsA), ...Object.keys(paramsB)]);
+  const diffs: ParamDiff[] = [];
+
+  for (const key of allKeys) {
+    const valueA = paramsA[key]?.value;
+    const valueB = paramsB[key]?.value;
+    diffs.push({
+      key,
+      valueA,
+      valueB,
+      changed: valueA !== valueB,
+    });
+  }
+
+  return diffs.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/**
+ * Compare steps between two runs by step_name.
+ * Steps present in only one run get null values for the missing side.
+ */
+export function computeStepDiffs(data: RunComparisonData): StepDiff[] {
+  const stepsA = new Map(data.runA.steps.map((s) => [s.step.step_name, s]));
+  const stepsB = new Map(data.runB.steps.map((s) => [s.step.step_name, s]));
+  const allStepNames = new Set([...stepsA.keys(), ...stepsB.keys()]);
+  const diffs: StepDiff[] = [];
+
+  for (const step_name of allStepNames) {
+    const a = stepsA.get(step_name);
+    const b = stepsB.get(step_name);
+    const durationA = a?.step.duration ?? null;
+    const durationB = b?.step.duration ?? null;
+
+    diffs.push({
+      step_name,
+      durationA,
+      durationB,
+      delta_ms: durationA !== null && durationB !== null ? durationB - durationA : null,
+      statusA: a?.status ?? 'unknown',
+      statusB: b?.status ?? 'unknown',
+    });
+  }
+
+  return diffs;
+}
+
+/**
+ * Compare artifact presence between two runs at the step level.
+ * Does not compare artifact values — only whether a given artifact key exists in each run.
+ */
+export function computeArtifactDiffs(data: RunComparisonData): ArtifactDiff[] {
+  const diffs: ArtifactDiff[] = [];
+
+  // Build a map of step_name -> Set<artifact_key> for each run
+  const artifactsA = new Map<string, Set<string>>();
+  for (const step of data.runA.steps) {
+    artifactsA.set(step.step.step_name, new Set(step.artifact_keys));
+  }
+
+  const artifactsB = new Map<string, Set<string>>();
+  for (const step of data.runB.steps) {
+    artifactsB.set(step.step.step_name, new Set(step.artifact_keys));
+  }
+
+  const allStepNames = new Set([...artifactsA.keys(), ...artifactsB.keys()]);
+
+  for (const step_name of allStepNames) {
+    const keysA = artifactsA.get(step_name) ?? new Set();
+    const keysB = artifactsB.get(step_name) ?? new Set();
+    const allKeys = new Set([...keysA, ...keysB]);
+
+    for (const key of allKeys) {
+      diffs.push({
+        step_name,
+        key,
+        inA: keysA.has(key),
+        inB: keysB.has(key),
+      });
+    }
+  }
+
+  return diffs;
+}

--- a/src/utils/comparison.ts
+++ b/src/utils/comparison.ts
@@ -67,7 +67,7 @@ export function computeStepDiffs(data: RunComparisonData): StepDiff[] {
     });
   }
 
-  return diffs;
+  return diffs.sort((a, b) => a.step_name.localeCompare(b.step_name));
 }
 
 /**


### PR DESCRIPTION
## Requirements for a pull request

- [x] Unit tests related to the change have been updated
- [ ] Documentation related to the change has been updated

## Description of the Change

This PR adds foundational types and a client-side diff engine for a run comparison view, where users can select any two runs of the same flow and immediately see what changed between them: parameter values, step durations, and artifact presence.

The goal was to add this incrementally rather than in a single large PR, so this is the data layer only. UI components and hooks will follow separately once this is reviewed.

### `src/types/comparison.ts`

All types are built by composing from the existing interfaces in `src/types.ts` (`Run`, `Step`, `Task`, `TaskStatus`, `RunParam`) so there is no duplication and the comparison view stays in sync with any future changes to those interfaces.

- `RunSnapshot` holds a run, its `RunParam` map, and an array of `StepSnapshot` objects
- `StepSnapshot` holds a `Step`, a `TaskStatus` (sourced from `getStepStatus` in `taskdataUtils.ts`), its `Task[]`, and artifact key names
- `RunComparisonData` is just `{ runA, runB }` and is the input to every diff function
- `RunDiff` is the output: `{ params: ParamDiff[], steps: StepDiff[], artifacts: ArtifactDiff[] }`
- `StepDiff` includes a `delta_ms` field (`null` when either side has no duration) which maps directly to how the existing timeline already handles incomplete timing data

The comments at the top of `types/comparison.ts` map each field to the specific existing endpoint it comes from (`/runs/{run_number}`, `/parameters`, `/steps`, `/tasks`, `/artifacts`).

### `src/utils/comparison.ts`

Four pure functions, no side effects, no API calls:

- **`computeParamDiffs(paramsA, paramsB)`**: unions all keys from both `RunParam` objects (which are plain string-keyed maps), checks value equality per key, sorts results alphabetically so diffs are stable across renders
- **`computeStepDiffs(data)`**: matches steps by `step_name`, computes `delta_ms = durationB - durationA`. Steps missing from one side get `null` durations and `'unknown'` status, consistent with how the rest of the app handles missing step data
- **`computeArtifactDiffs(data)`**: compares artifact key presence per step, not artifact values. Artifact values would require additional per-artifact fetches which are expensive; presence diffing is enough to show what the run produced or lost
- **`computeRunDiff(data)`**: composes all three into a single `RunDiff`

### `src/utils/__tests__/comparison.test.cypress.ts`

12 test cases using `createRun`, `createStep`, `createTask` from `testhelper.ts` and Chai assertions, matching the conventions in the existing test files. A local `makeSnapshot` helper keeps each test focused on the case being tested rather than boilerplate.

`computeParamDiffs`: identical params, changed value, params in only one run, empty params
`computeStepDiffs`: duration delta, step in only one run, null delta when duration missing, alphabetical sort by step_name
`computeArtifactDiffs`: both runs have artifact, one run missing artifact, empty artifact lists
`computeRunDiff`: full integration with params + steps + artifacts in one snapshot

No new API endpoints are needed.

## Alternate Designs

**Server-side diff endpoint:** Considered adding a `/compare` endpoint that returns a pre-computed diff. Decided against it because all the necessary data is already fetched by existing hooks (`useResource`) when viewing a run, the dataset per run is small enough that client-side diffing adds no perceptible cost, and it avoids requiring backend changes for a frontend-driven feature.

**General-purpose diff library (`deep-diff`, `microdiff`):** Rejected to avoid adding a new dependency. The three diff operations are domain-specific enough (step duration delta, artifact presence, param value equality) that a small handwritten implementation is clearer and easier to test precisely.

## Possible Drawbacks

This PR contains no UI and will produce no visible change on its own. The types may need revision once the comparison view components are designed in detail, but since they compose from existing interfaces rather than duplicating fields, the surface area for breaking changes is small.

## Verification Process

```bash
yarn cypress run --component --spec "src/utils/__tests__/comparison.test.cypress.ts"