### PR TITLE
fix: show logs for tasks killed by runtime without finished_at

### DIFF
--- a/src/pages/Task/index.tsx
+++ b/src/pages/Task/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { SetQuery, StringParam, useQueryParams } from 'use-query-params';
 import { apiHttp } from '@/constants';
-import { Artifact, AsyncStatus, Run as IRun, Task as ITask } from '@/types';
+import { Artifact, AsyncStatus, Run as IRun, Task as ITask, TaskStatus } from '@/types';
 import AnchoredView from '@pages/Task/components/AnchoredView';
 import ArtifactActionBar from '@pages/Task/components/ArtifactActionBar';
 import ArtifactTable from '@pages/Task/components/ArtifactTable';
@@ -73,6 +73,11 @@ const updatePredicate = (a: ITask, b: ITask) => a.attempt_id === b.attempt_id;
 const emptyFn = () => {
   /*intentional*/
 };
+
+// Tasks killed by the runtime (e.g. Titus OOM/eviction) never write attempt-done
+// metadata, so finished_at stays null. Treat these terminal statuses as done so
+// logs are fetched regardless.
+const TERMINAL_TASK_STATUSES: TaskStatus[] = ['completed', 'failed', 'unknown'];
 
 //
 // Component
@@ -163,7 +168,7 @@ const Task: React.FC<TaskViewProps> = ({
     }
   }, [task, addDataToStore]);
 
-  const isCurrentTaskFinished = !!(task && task.finished_at);
+  const isCurrentTaskFinished = !!(task && (task.finished_at || TERMINAL_TASK_STATUSES.includes(task.status)));
   const isLatestAttempt = attemptId === (tasks?.length || 1) - 1;
 
   const handleToggleCollapse = (type: 'expand' | 'collapse') =>


### PR DESCRIPTION
## Problem

When a Metaflow task is killed by the runtime (e.g. Titus OOM or eviction), the in-container agent is also killed before it can write the `attempt-done` metadata record. This leaves `finished_at = null` on the task object returned by the backend.

The UI gates log fetching on `isCurrentTaskFinished = !!(task && task.finished_at)`. With `finished_at` null, `isCurrentTaskFinished` is `false`, `paused` is `true` in both `useLogData` calls, and logs are *never fetched* — even though they exist in S3.

**The logs are there. The UI just never asks for them.**

## Fix

Treat any terminal task status (`completed`, `failed`, `unknown`) as "finished enough" to fetch logs, regardless of whether `finished_at` is populated:

```ts
// Before
const isCurrentTaskFinished = !!(task && task.finished_at);

// After
const isCurrentTaskFinished = !!(task && (task.finished_at || TERMINAL_TASK_STATUSES.includes(task.status)));
```

The `preload` path for live streaming is unchanged — it still only activates for `status === 'running'`.

## Test plan

- [ ] Task killed by Titus (status=`failed`, `finished_at=null`): logs now appear in the UI
- [ ] Normal completed task (status=`completed`, `finished_at` set): logs still appear (no regression)
- [ ] Running task: live log streaming still works via the `preload` path
- [ ] Task with `unknown` status: logs now appear if they exist in S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)